### PR TITLE
Fix code-review findings in inspection panels

### DIFF
--- a/SaturnExplorer/Core/src/Context.h
+++ b/SaturnExplorer/Core/src/Context.h
@@ -240,6 +240,7 @@ public:
 
     bool HasVdp1Regs() const { return mSnapshot.HasVdp1Regs(); }
     bool HasVdp2Regs() const { return mSnapshot.HasVdp2Regs(); }
+    se_cram_mode CramMode() const { return mSnapshot.CramMode(); }
     uint16_t Vdp1Register(uint32_t hw) const { return mSnapshot.Vdp1Reg(hw); }
     uint16_t Vdp2Register(uint32_t hw) const { return mSnapshot.Vdp2Reg(hw); }
 

--- a/SaturnExplorer/Core/src/HostAbi.cpp
+++ b/SaturnExplorer/Core/src/HostAbi.cpp
@@ -196,6 +196,11 @@ size_t se_read_cram_colors(se_context* ctx, uint16_t start, uint16_t count,
     return ctx ? Impl(ctx)->ReadCramColors(start, count, out) : 0;
 }
 
+se_cram_mode se_get_cram_mode(se_context* ctx)
+{
+    return ctx ? Impl(ctx)->CramMode() : SE_CRAM_RGB555_1024;
+}
+
 /* --- ROM & Archive Search --- */
 se_search_handle se_rom_search_begin(se_context* ctx, const se_search_query* q)
 {

--- a/SaturnExplorer/Drivers/Savestate/src/SavestateDriver.cpp
+++ b/SaturnExplorer/Drivers/Savestate/src/SavestateDriver.cpp
@@ -362,6 +362,57 @@ void CopyMednafenU16BE(const std::vector<uint8_t>& file, size_t off, uint32_t si
     }
 }
 
+// Mednafen stores VDP1's control/status registers as individual named scalar
+// fields inside the "VDP1" section (TVMR/FBCR/PTMR/EDSR are uint8; EWDR/EWLR/
+// EWRR/LOPR are uint16), not as a contiguous register file like VDP2's RawRegs.
+// Reassemble them into a hardware-offset big-endian image so the shared
+// read_vdp1_reg serves them like any other register file. ENDR is write-only
+// and COPR/MODR are computed, so those hardware slots stay zero. Returns true if
+// at least one field was found (leaving 'out' empty otherwise, so the driver
+// reports no VDP1 registers rather than a table of zeros).
+bool BuildVdp1RegImageFromMednafen(const std::vector<uint8_t>& file, size_t secData,
+                                   uint32_t secSize, bool hostBigEndian,
+                                   std::vector<uint8_t>& out)
+{
+    struct Field { const char* name; uint32_t hw; };
+    static const Field kFields[] = {
+        {"TVMR", 0x00}, {"FBCR", 0x02}, {"PTMR", 0x04},
+        {"EWDR", 0x06}, {"EWLR", 0x08}, {"EWRR", 0x0A},
+        {"EDSR", 0x10}, {"LOPR", 0x12},
+    };
+    out.assign(0x18, 0);   // covers hw 0x00..0x16
+    int found = 0;
+    for (const Field& f : kFields)
+    {
+        size_t off; uint32_t sz;
+        if (!FindMednafenField(file, secData, secSize, f.name, off, sz) || sz == 0)
+        {
+            continue;
+        }
+        uint16_t val;
+        if (sz == 1)
+        {
+            val = file[off];
+        }
+        else if (hostBigEndian)
+        {
+            val = static_cast<uint16_t>((file[off] << 8) | file[off + 1]);
+        }
+        else
+        {
+            val = static_cast<uint16_t>(file[off] | (file[off + 1] << 8));
+        }
+        out[f.hw]     = static_cast<uint8_t>(val >> 8);
+        out[f.hw + 1] = static_cast<uint8_t>(val & 0xFF);
+        ++found;
+    }
+    if (!found)
+    {
+        out.clear();
+    }
+    return found != 0;
+}
+
 // Parse an already-loaded .yss buffer into '*out' (zeroed by the caller). Kept
 // separate from the path entry point so the dispatcher can reuse a single read.
 se_result ParseYssBuffer(const std::vector<uint8_t>& file, se_data_source* out)
@@ -492,6 +543,9 @@ se_result ParseMednafenBuffer(const std::vector<uint8_t>& file, se_data_source* 
                 CopyMednafenU16BE(file, off, kVramSize, state->mVdp1Vram, swap);
                 haveVdp1 = true;
             }
+            // VDP1 control/status registers live as individual named fields.
+            BuildVdp1RegImageFromMednafen(file, secData, secSize, hostBigEndian,
+                                          state->mVdp1Regs);
         }
         else if (std::strcmp(name, "VDP2") == 0)
         {

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -1248,12 +1248,14 @@ void App::DrawColorRam()
         }
         else
         {
-            static std::vector<se_palette_entry> colors;
-            colors.resize(2048);
+            mCramColors.resize(2048);
             const size_t n = se_read_cram_colors(mContext, 0,
-                                                 static_cast<uint16_t>(colors.size()),
-                                                 colors.data());
-            ImGui::Text("%zu CRAM entries", n);
+                                                 static_cast<uint16_t>(mCramColors.size()),
+                                                 mCramColors.data());
+            const se_cram_mode mode = se_get_cram_mode(mContext);
+            const bool rgb888 = (mode == SE_CRAM_RGB888_1024);
+            ImGui::Text("%zu CRAM entries  (%s)", n,
+                        rgb888 ? "RGB888" : "RGB555");
             const int cols = 32;
             const float sw = 12.0f;
             ImDrawList* dl = ImGui::GetWindowDrawList();
@@ -1264,7 +1266,7 @@ void App::DrawColorRam()
                 const int cy = static_cast<int>(i) / cols;
                 const ImVec2 a(origin.x + cx * sw, origin.y + cy * sw);
                 const ImVec2 b(a.x + sw - 1.0f, a.y + sw - 1.0f);
-                const se_palette_entry& e = colors[i];
+                const se_palette_entry& e = mCramColors[i];
                 dl->AddRectFilled(a, b, IM_COL32(e.r, e.g, e.b, 255));
             }
             const int rows = (static_cast<int>(n) + cols - 1) / cols;
@@ -1277,9 +1279,19 @@ void App::DrawColorRam()
                 const int idx = cy * cols + cx;
                 if (cx >= 0 && cx < cols && idx >= 0 && idx < static_cast<int>(n))
                 {
-                    const se_palette_entry& e = colors[idx];
+                    const se_palette_entry& e = mCramColors[idx];
                     ImGui::BeginTooltip();
-                    ImGui::Text("CRAM #%d   raw 0x%04X", idx, e.raw);
+                    // RGB888 packs 24 bits, which won't fit e.raw (16-bit); show the
+                    // reconstructed color instead of a misleading 0x0000.
+                    if (rgb888)
+                    {
+                        ImGui::Text("CRAM #%d   RGB888 0x%06X", idx,
+                                    (e.r << 16) | (e.g << 8) | e.b);
+                    }
+                    else
+                    {
+                        ImGui::Text("CRAM #%d   raw 0x%04X", idx, e.raw);
+                    }
                     ImGui::Text("RGB  %d, %d, %d", e.r, e.g, e.b);
                     ImGui::EndTooltip();
                 }
@@ -1300,7 +1312,7 @@ void App::DrawVdp1Table()
         else
         {
             const size_t count = se_command_count(mContext);
-            ImGui::Text("%zu command tables (raw 16-word entries)", count);
+            ImGui::Text("%zu command tables (15 words each: CMDCTRL - GRDA)", count);
             const ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                           ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollX;
             if (ImGui::BeginTable("vdp1table", 3, flags))
@@ -1365,7 +1377,9 @@ void App::DrawVdp2Table()
             const uint16_t prina = R(0x0F8);
             const uint16_t prinb = R(0x0FA);
 
-            const char* colorName[8] = { "16", "256", "2048", "32K", "16M", "?", "?", "?" };
+            // NBG color counts max out at 32K (N0CHCN=3); higher codes are
+            // reserved for NBG, so they read as unknown rather than a real depth.
+            const char* colorName[8] = { "16", "256", "2048", "32K", "?", "?", "?", "?" };
             const uint32_t colorNum[4] = {
                 (cha & 0x0070u) >> 4, (cha & 0x3000u) >> 12,
                 (chb & 0x0002u) >> 1, (chb & 0x0020u) >> 5 };

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -61,6 +61,9 @@ private:
     int            mSelectedCommand = -1;
     bool           mbLayoutBuilt = false;   // default dock layout applied once
 
+    // Scratch buffer for the Color RAM panel, decoded once per frame.
+    std::vector<se_palette_entry> mCramColors;
+
     // VDP Output frame texture.
     TextureHandle        mFrameTexture = 0;
     int                  mFrameWidth = 0;

--- a/SaturnExplorer/include/saturnexplorer/SeHost.h
+++ b/SaturnExplorer/include/saturnexplorer/SeHost.h
@@ -89,6 +89,9 @@ size_t      se_read_vram(se_context* ctx, se_vram_kind kind, uint32_t offset,
    number written (clamped to the CRAM size for the current color mode). */
 size_t      se_read_cram_colors(se_context* ctx, uint16_t start, uint16_t count,
                                 se_palette_entry* out);
+/* The CRAM color mode of the current snapshot (fixes entry width: RGB555 words
+   vs RGB888 dwords). Returns SE_CRAM_RGB555_1024 when no data is loaded. */
+se_cram_mode se_get_cram_mode(se_context* ctx);
 
 /* --- ROM & Archive Search / Asset Trace (async; poll incrementally) --- */
 typedef struct se_search* se_search_handle;


### PR DESCRIPTION
Addresses all five findings from the code review of the inspection-panels change.

## Fixes
1. **Mednafen VDP1 registers were never surfaced (the substantive one).** The Mednafen parser extracted only the VDP1 `VRAM` field, so `SE_CAP_VDP1_REGS` was never set and the Registers → "VDP1" tab always showed "unavailable" — even though Mednafen states carry those registers. Mednafen stores them as individual named scalar fields (`TVMR`/`FBCR`/`PTMR`/`EDSR` u8, `EWDR`/`EWLR`/`EWRR`/`LOPR` u16), so the driver now reassembles them into a hardware-offset big-endian register image, leaving it absent when none are found.
2. **Color RAM RGB888 tooltip showed `raw 0x0000`** for every entry (the 16-bit `raw` field can't hold a 24-bit value). Added `se_get_cram_mode` and the tooltip now shows the reconstructed 24-bit color in RGB888 mode.
3. **Color RAM's per-frame decode buffer was a function-local `static`;** moved it to an `App` member.
4. **VDP2 Table listed "16M"** as an NBG color depth; NBG maxes at 32K, so higher codes now read as unknown.
5. **VDP1 Table header claimed "16-word entries"** but rendered 15; the text now matches (CMDCTRL – GRDA).

## Verification
- Frontend and core build clean with `-Wall -Wextra -Werror`.
- Battle3 `.yss` render byte-identical to the golden reference — no regression.
- `.yss` inspection unchanged (VDP1 registers correctly absent, as that format doesn't store them).
- A synthesized Mednafen state decodes all eight VDP1 registers with correct endianness (`caps=0x11`, `has_vdp1_regs=1`, values match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_