### PR TITLE
3D-view picking, shift-click multi-select, texture byte size

### DIFF
--- a/SaturnExplorer/Core/src/Context.h
+++ b/SaturnExplorer/Core/src/Context.h
@@ -312,6 +312,19 @@ public:
         return SE_ERR_NO_DATA;
     }
 
+    // Topmost 3D sprite under the screen point for 'camera' (matches the 3D view).
+    se_result HitTest3D(const se_camera3d& camera, int x, int y,
+                        size_t* outCommandIndex) const
+    {
+        uint32_t cmd = 0;
+        if (Vdp1Rasterizer::HitTest3D(mScene, camera, x, y, &cmd))
+        {
+            *outCommandIndex = cmd;
+            return SE_OK;
+        }
+        return SE_ERR_NO_DATA;
+    }
+
     size_t VramRegionCount() const { return mVramRegions.size(); }
 
     se_result GetVramRegion(size_t index, se_vram_region* out) const

--- a/SaturnExplorer/Core/src/HostAbi.cpp
+++ b/SaturnExplorer/Core/src/HostAbi.cpp
@@ -74,6 +74,16 @@ se_result se_hit_test(se_context* ctx, int x, int y, size_t* out_index)
     return Impl(ctx)->HitTest(x, y, out_index);
 }
 
+se_result se_hit_test_3d(se_context* ctx, const se_camera3d* camera,
+                         int x, int y, size_t* out_index)
+{
+    if (!ctx || !camera || !out_index)
+    {
+        return SE_ERR_INVALID_ARG;
+    }
+    return Impl(ctx)->HitTest3D(*camera, x, y, out_index);
+}
+
 /* --- VDP1 geometry --- */
 size_t se_sprite_count(se_context* ctx)
 {

--- a/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
+++ b/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
@@ -234,6 +234,56 @@ void Vdp1Rasterizer::Render3D(const Vdp1Scene& scene, const std::vector<uint8_t>
     }
 }
 
+bool Vdp1Rasterizer::HitTest3D(const Vdp1Scene& scene, const se_camera3d& camera,
+                               int x, int y, uint32_t* outCmd)
+{
+    const float cosYaw = std::cos(camera.yaw);
+    const float sinYaw = std::sin(camera.yaw);
+    const float cosPitch = std::cos(camera.pitch);
+    const float sinPitch = std::sin(camera.pitch);
+    const float px = static_cast<float>(x);
+    const float py = static_cast<float>(y);
+
+    auto inTri = [&](const RVert& p0, const RVert& p1, const RVert& p2)
+    {
+        const float e0 = Edge(p0.x, p0.y, p1.x, p1.y, px, py);
+        const float e1 = Edge(p1.x, p1.y, p2.x, p2.y, px, py);
+        const float e2 = Edge(p2.x, p2.y, p0.x, p0.y, px, py);
+        const bool hasNeg = (e0 < 0) || (e1 < 0) || (e2 < 0);
+        const bool hasPos = (e0 > 0) || (e1 > 0) || (e2 > 0);
+        return !(hasNeg && hasPos);
+    };
+
+    bool found = false;
+    float bestDepth = 0.0f;
+    uint32_t bestCmd = 0;
+    for (const se_sprite_3d& g : scene.sprites3d)
+    {
+        const RVert v[4] = {
+            Project(g.corners[0], camera, cosYaw, sinYaw, cosPitch, sinPitch),
+            Project(g.corners[1], camera, cosYaw, sinYaw, cosPitch, sinPitch),
+            Project(g.corners[2], camera, cosYaw, sinYaw, cosPitch, sinPitch),
+            Project(g.corners[3], camera, cosYaw, sinYaw, cosPitch, sinPitch) };
+        if (!(inTri(v[0], v[1], v[2]) || inTri(v[0], v[2], v[3])))
+        {
+            continue;
+        }
+        // Nearest to the camera wins (smallest projected depth = z2).
+        const float depth = (v[0].depth + v[1].depth + v[2].depth + v[3].depth) * 0.25f;
+        if (!found || depth < bestDepth)
+        {
+            found = true;
+            bestDepth = depth;
+            bestCmd = g.command_index;
+        }
+    }
+    if (found && outCmd)
+    {
+        *outCmd = bestCmd;
+    }
+    return found;
+}
+
 bool PointInSprite(const se_sprite_2d& sprite, float px, float py)
 {
     const se_vec2& a = sprite.corners[0];

--- a/SaturnExplorer/Core/src/Vdp1Rasterizer.h
+++ b/SaturnExplorer/Core/src/Vdp1Rasterizer.h
@@ -29,6 +29,12 @@ public:
                          const std::vector<uint8_t>& cram, se_cram_mode cramMode,
                          const se_camera3d& camera, const se_render_opts& opts,
                          std::vector<uint8_t>& outRgba, std::vector<float>& depth);
+
+    // Pick the topmost 3D sprite under screen point (x,y) for 'camera', using the
+    // exact same projection as Render3D. Returns true and writes the winning
+    // sprite's command index to *outCmd; false if the point hits no sprite.
+    static bool HitTest3D(const Vdp1Scene& scene, const se_camera3d& camera,
+                          int x, int y, uint32_t* outCmd);
 };
 
 // True if screen point (px,py) falls inside the sprite's quad (either triangle).

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -1,5 +1,6 @@
 #include "App.h"
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstdio>
 #include <string>
@@ -60,6 +61,21 @@ const char* ColorModeName(se_color_mode mode)
     }
 }
 
+// Bytes this command's texture occupies in VDP1 VRAM. Mirrors the core's
+// TextureByteSize (Core/src/Context.h) — bpp keyed by colour mode. Non-textured
+// commands (clips, coords) have zero width/height and so return 0.
+uint32_t TextureVramBytes(const se_command& c)
+{
+    const uint32_t pixels = static_cast<uint32_t>(c.width) * c.height;
+    switch (c.color_mode)
+    {
+    case SE_COLOR_BANK_16:
+    case SE_COLOR_LUT_16:   return pixels / 2;   // 4 bpp
+    case SE_COLOR_RGB555:   return pixels * 2;   // 16 bpp
+    default:                return pixels;       // 8 bpp bank modes
+    }
+}
+
 const char* DrawModeName(se_draw_mode mode)
 {
     switch (mode)
@@ -117,10 +133,48 @@ void App::CloseData()
     }
     mbHasData = false;
     mSelectedCommand = -1;
+    mSelection.clear();
     // The frame texture is freed lazily (on next size change) or with the
     // platform's device at shutdown; mark it stale so a new dump recreates it.
     mFrameWidth = 0;
     mFrameHeight = 0;
+}
+
+void App::SelectCommand(int command, bool additive)
+{
+    if (command < 0)
+    {
+        return;
+    }
+    if (additive)
+    {
+        // Toggle this command in/out of the multi-selection.
+        auto it = std::find(mSelection.begin(), mSelection.end(), command);
+        if (it != mSelection.end())
+        {
+            mSelection.erase(it);
+            if (mSelectedCommand == command)
+            {
+                mSelectedCommand = mSelection.empty() ? -1 : mSelection.back();
+            }
+        }
+        else
+        {
+            mSelection.push_back(command);
+            mSelectedCommand = command;   // newest becomes primary
+        }
+    }
+    else
+    {
+        mSelection.assign(1, command);
+        mSelectedCommand = command;
+    }
+}
+
+bool App::IsSelected(int command) const
+{
+    return command >= 0 &&
+           std::find(mSelection.begin(), mSelection.end(), command) != mSelection.end();
 }
 
 // Recreate 'tex' when the target size changes; updates cached w/h. Returns the
@@ -529,7 +583,7 @@ void App::DrawVdpOutput(IPlatform& platform)
 
             // Only walk the sprite list when an overlay actually needs it.
             const bool wantOverlays = mRenderOpts.show_bounding_boxes ||
-                                      mRenderOpts.show_object_numbers || mSelectedCommand >= 0;
+                                      mRenderOpts.show_object_numbers || !mSelection.empty();
             const size_t spriteCount = wantOverlays ? se_sprite_count(mContext) : 0;
             for (size_t i = 0; i < spriteCount; ++i)
             {
@@ -538,7 +592,7 @@ void App::DrawVdpOutput(IPlatform& platform)
                 {
                     continue;
                 }
-                const bool selected = (static_cast<int>(sprite.command_index) == mSelectedCommand);
+                const bool selected = IsSelected(static_cast<int>(sprite.command_index));
                 if (mRenderOpts.show_bounding_boxes || selected)
                 {
                     const ImVec2 c0 = toScreen(sprite.corners[0]);
@@ -573,7 +627,7 @@ void App::DrawVdpOutput(IPlatform& platform)
                 size_t hitCommand = 0;
                 if (se_hit_test(mContext, vx, vy, &hitCommand) == SE_OK)
                 {
-                    mSelectedCommand = static_cast<int>(hitCommand);
+                    SelectCommand(static_cast<int>(hitCommand), ImGui::GetIO().KeyShift);
                     mScrollCommandListToSelection = true;
                 }
             }
@@ -620,8 +674,15 @@ void App::DrawWorldView(IPlatform& platform)
                 }
 
                 ImGui::Image(m3dTexture, ImVec2(static_cast<float>(vw), static_cast<float>(vh)));
+                const ImVec2 imgMin = ImGui::GetItemRectMin();
+                const bool hovered = ImGui::IsItemHovered();
 
-                if (ImGui::IsItemHovered())
+                // Record where a left-press started, to tell a click from an orbit.
+                if (hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+                {
+                    m3dPressPos = ImGui::GetMousePos();
+                }
+                if (hovered)
                 {
                     if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
                     {
@@ -637,6 +698,25 @@ void App::DrawWorldView(IPlatform& platform)
                     {
                         mDistance *= (1.0f - wheel * 0.1f);
                         if (mDistance < 50.0f) mDistance = 50.0f;
+                    }
+                }
+                // A left-release that barely moved is a click: pick the sprite under
+                // it (same camera the frame was rendered with).
+                if (hovered && ImGui::IsMouseReleased(ImGuiMouseButton_Left))
+                {
+                    const ImVec2 up = ImGui::GetMousePos();
+                    const float dx = up.x - m3dPressPos.x;
+                    const float dy = up.y - m3dPressPos.y;
+                    if (dx * dx + dy * dy < 16.0f)
+                    {
+                        size_t hit = 0;
+                        if (se_hit_test_3d(mContext, &cam,
+                                           static_cast<int>(up.x - imgMin.x),
+                                           static_cast<int>(up.y - imgMin.y), &hit) == SE_OK)
+                        {
+                            SelectCommand(static_cast<int>(hit), ImGui::GetIO().KeyShift);
+                            mScrollCommandListToSelection = true;
+                        }
                     }
                 }
             }
@@ -698,10 +778,10 @@ void App::DrawCommandList()
                         ImGui::TableNextColumn();
                         char label[16];
                         std::snprintf(label, sizeof(label), "%d", row);
-                        if (ImGui::Selectable(label, mSelectedCommand == row,
+                        if (ImGui::Selectable(label, IsSelected(row),
                                               ImGuiSelectableFlags_SpanAllColumns))
                         {
-                            mSelectedCommand = row;
+                            SelectCommand(row, ImGui::GetIO().KeyShift);
                         }
                         if (doScroll && row == mSelectedCommand)
                         {
@@ -710,7 +790,15 @@ void App::DrawCommandList()
                         ImGui::TableNextColumn();
                         ImGui::TextUnformatted(CommandTypeName(cmd.type));
                         ImGui::TableNextColumn();
-                        ImGui::Text("%ux%u", cmd.width, cmd.height);
+                        const uint32_t texBytes = TextureVramBytes(cmd);
+                        if (texBytes > 0)
+                        {
+                            ImGui::Text("%ux%u (%u B)", cmd.width, cmd.height, texBytes);
+                        }
+                        else
+                        {
+                            ImGui::Text("%ux%u", cmd.width, cmd.height);
+                        }
                         ImGui::TableNextColumn();
                         ImGui::Text("(%d, %d)", cmd.x, cmd.y);
                         ImGui::TableNextColumn();
@@ -1052,8 +1140,7 @@ void App::DrawVramMap()
                 }
                 const uint32_t end = reg.address + (reg.size ? reg.size : 1);
                 const ImU32 col = kindColor(reg.kind);
-                const bool isSelected = (mSelectedCommand >= 0 &&
-                                         static_cast<int>(reg.ref_index) == mSelectedCommand);
+                const bool isSelected = IsSelected(static_cast<int>(reg.ref_index));
                 // A region can straddle rows; paint it row by row, outlining each
                 // slice so neighbouring same-kind blocks read as distinct items.
                 uint32_t a = reg.address;
@@ -1118,7 +1205,7 @@ void App::DrawVramMap()
             // which the VDP Output panel then highlights (via mSelectedCommand).
             if (mapClicked && nearestRef != 0xFFFFFFFFu)
             {
-                mSelectedCommand = static_cast<int>(nearestRef);
+                SelectCommand(static_cast<int>(nearestRef), ImGui::GetIO().KeyShift);
                 mScrollCommandListToSelection = true;
             }
             ImGui::Spacing();
@@ -1171,10 +1258,10 @@ void App::DrawReferenceList(const char* id, const std::vector<se_reference>& ref
             ImGui::TableNextColumn();
             char label[24];
             std::snprintf(label, sizeof(label), "%u", r.command_index);
-            const bool selected = (mSelectedCommand == static_cast<int>(r.command_index));
+            const bool selected = IsSelected(static_cast<int>(r.command_index));
             if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns))
             {
-                mSelectedCommand = static_cast<int>(r.command_index);
+                SelectCommand(static_cast<int>(r.command_index), ImGui::GetIO().KeyShift);
                 mScrollCommandListToSelection = true;
             }
             ImGui::TableNextColumn();

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -57,16 +57,24 @@ private:
     void DrawVdp2Table();
     void DrawPlaceholder(const char* title, const char* note);
 
+    // Selection helpers. mSelectedCommand is the "primary" (what the detail panels
+    // show); mSelection is the full set of highlighted commands. A plain click
+    // selects one; shift-click (additive) toggles a command in/out of the set.
+    void SelectCommand(int command, bool additive);
+    bool IsSelected(int command) const;
+
     se_data_source mDataSource {};
     se_context*    mContext = nullptr;
     bool           mbHasData = false;
 
-    se_render_opts mRenderOpts {};
-    int            mSelectedCommand = -1;
-    bool           mbLayoutBuilt = false;   // default dock layout applied once
+    se_render_opts   mRenderOpts {};
+    int              mSelectedCommand = -1;   // primary selection (detail panels)
+    std::vector<int> mSelection;              // all selected command indices
+    bool             mbLayoutBuilt = false;   // default dock layout applied once
     // Set when an external panel (VDP Output / VRAM Map / References) changes the
     // selection, so the Command List scrolls its highlighted row into view once.
-    bool           mScrollCommandListToSelection = false;
+    bool             mScrollCommandListToSelection = false;
+    ImVec2           m3dPressPos {};          // 3D-view press point (click vs orbit)
 
     // Scratch buffer for the Color RAM panel, decoded once per frame.
     std::vector<se_palette_entry> mCramColors;

--- a/SaturnExplorer/include/saturnexplorer/SeHost.h
+++ b/SaturnExplorer/include/saturnexplorer/SeHost.h
@@ -38,6 +38,9 @@ se_result   se_begin_frame(se_context* ctx);
 size_t      se_command_count(se_context* ctx);
 se_result   se_get_command (se_context* ctx, size_t index, se_command* out);
 se_result   se_hit_test    (se_context* ctx, int x, int y, size_t* out_index);
+/* Pick the topmost 3D sprite under (x,y) for 'camera' (the 3D View's camera). */
+se_result   se_hit_test_3d (se_context* ctx, const se_camera3d* camera,
+                            int x, int y, size_t* out_index);
 
 /* --- VDP1 geometry: every sprite emitted in TWO coordinate spaces (§7). --- */
 size_t      se_sprite_count  (se_context* ctx);


### PR DESCRIPTION
Three UX additions building on the shared selection model.

## 3D View click-to-select
- New core `se_hit_test_3d(ctx, camera, x, y, &cmd)` — reuses the **exact** orbit projection (`Vdp1Rasterizer::Project`) that `Render3D` uses, so picks line up with what's drawn, and returns the topmost (nearest-depth) sprite. Additive ABI function — no struct change, no version bump.
- `DrawWorldView` selects on a left-release that barely moved (so it doesn't fire while orbiting), hit-testing with the same camera the frame was rendered with.

## Shift-click multi-select
- Selection is now a set (`mSelection`) with `mSelectedCommand` as the **primary**. Plain click selects one; **shift-click toggles** a sprite in/out of the set. Works uniformly in VDP Output, 3D View, VRAM Map, Command List, and References.
- All highlight readers use `IsSelected(...)`; the detail panels (Selected Object / Texture / Palette) and the list auto-scroll still follow the primary.

## Texture byte size in the Command List
- The **Size** column now appends the texture's VRAM footprint, e.g. `16x7 (56 B)`, via a small frontend helper mirroring Core `TextureByteSize` (bpp keyed by colour mode). Shown only for textured commands.

## Verification
- Core hit-test harness: sampled sprites are picked at their projected centroid (exact or the correct overlapping topmost), and an off-screen point misses.
- 2D golden render byte-identical (core render untouched).
- Headless frontend with a forced two-sprite selection: both sprites highlighted in VDP Output, both blocks in the VRAM Map, the primary row highlighted + scrolled in the Command List, and the Size column showing `WxH (N B)` (verified 112px×4bpp = 56 B, 800px = 400 B, …).
- `App.cpp` + core build clean (`-Wall -Wextra -Werror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_