### PR TITLE
M7: Live driver — realtime VDP data from a running Yabause

### DIFF
--- a/SaturnExplorer/BUILD.md
+++ b/SaturnExplorer/BUILD.md
@@ -64,6 +64,14 @@ and open it in a browser. Load a savestate by **dragging it onto the canvas** or
 toolbar's **Open** button. Every push to `master` also builds and publishes this to GitHub
 Pages via `.github/workflows/web.yml`.
 
+### Live mode — inspect a running emulator (native builds)
+The Windows and native-SDL2 builds can read a **running** Yabause in realtime
+instead of a savestate. Apply the small patch in
+[`Integration/Yabause/`](Integration/Yabause/README.md) to your Yabause build, run
+a game, then launch Saturn Explorer with `--live` (or use **Open ▸ Connect to
+Yabause**). Every panel then tracks the live game. (The web build is savestate-only
+— live mode needs sockets/threads.)
+
 ---
 
 ## Option 2 — the checked-in Visual Studio solution

--- a/SaturnExplorer/CMakeLists.txt
+++ b/SaturnExplorer/CMakeLists.txt
@@ -43,6 +43,17 @@ target_include_directories(SaturnExplorerCore
 )
 
 # ---------------------------------------------------------------------------
+# Driver common — shared, portable helpers (endian normalization + VDP2 register
+# image reconstruction) used by the savestate and live drivers.
+# ---------------------------------------------------------------------------
+add_library(SaturnExplorerDriverCommon STATIC
+    Drivers/Common/src/SaturnStateShared.cpp
+)
+target_include_directories(SaturnExplorerDriverCommon
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/Common/src
+)
+
+# ---------------------------------------------------------------------------
 # Savestate / memory-dump driver — portable static library (Seam A reference).
 # ---------------------------------------------------------------------------
 add_library(SaturnExplorerSavestateDriver STATIC
@@ -52,7 +63,29 @@ target_include_directories(SaturnExplorerSavestateDriver
     PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/Savestate/src
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-target_link_libraries(SaturnExplorerSavestateDriver PUBLIC SaturnExplorerCore)
+target_link_libraries(SaturnExplorerSavestateDriver
+    PUBLIC SaturnExplorerCore SaturnExplorerDriverCommon)
+
+# ---------------------------------------------------------------------------
+# Live driver — reads a running, patched Yabause over a local socket. Uses
+# threads + sockets, so it's native only (never built under Emscripten).
+# ---------------------------------------------------------------------------
+if(NOT EMSCRIPTEN)
+    add_library(SaturnExplorerLiveDriver STATIC
+        Drivers/Live/src/LiveDriver.cpp
+    )
+    target_include_directories(SaturnExplorerLiveDriver
+        PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/Live/src
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(SaturnExplorerLiveDriver
+        PUBLIC SaturnExplorerCore SaturnExplorerDriverCommon)
+    find_package(Threads REQUIRED)
+    target_link_libraries(SaturnExplorerLiveDriver PUBLIC Threads::Threads)
+    if(WIN32)
+        target_link_libraries(SaturnExplorerLiveDriver PUBLIC ws2_32)
+    endif()
+endif()
 
 # ---------------------------------------------------------------------------
 # FrontEnd — reference app (Dear ImGui). Three interchangeable Seam C backends:
@@ -88,10 +121,14 @@ if(WIN32)
     target_compile_definitions(SaturnExplorerFrontEnd PRIVATE
         WIN32_LEAN_AND_MEAN
         NOMINMAX
+        SE_ENABLE_LIVE
     )
+    target_include_directories(SaturnExplorerFrontEnd PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/Live/src)
     target_link_libraries(SaturnExplorerFrontEnd PRIVATE
         SaturnExplorerCore
         SaturnExplorerSavestateDriver
+        SaturnExplorerLiveDriver
         d3d11
         dxgi
         d3dcompiler
@@ -154,10 +191,13 @@ else()
             ${SE_IMGUI_DIR}
             ${SE_IMGUI_DIR}/backends
             ${SDL2_INCLUDE_DIRS}
+            ${CMAKE_CURRENT_SOURCE_DIR}/Drivers/Live/src
         )
+        target_compile_definitions(SaturnExplorerFrontEnd PRIVATE SE_ENABLE_LIVE)
         target_link_libraries(SaturnExplorerFrontEnd PRIVATE
             SaturnExplorerCore
             SaturnExplorerSavestateDriver
+            SaturnExplorerLiveDriver
             ${SDL2_LIBRARIES}
             OpenGL::GL
         )

--- a/SaturnExplorer/Drivers/Common/src/SaturnStateShared.cpp
+++ b/SaturnExplorer/Drivers/Common/src/SaturnStateShared.cpp
@@ -1,0 +1,85 @@
+// See SaturnStateShared.h. These were originally file-static in the savestate
+// driver; hoisted here verbatim so the live driver reuses the exact same logic.
+
+#include "SaturnStateShared.h"
+
+namespace sedrv
+{
+
+namespace
+{
+constexpr uint32_t kVdp2RegMax = 0x11E;   // highest VDP2 register (COBB)
+
+// Exact hardware-offset -> Yabause 0.9.15 Vdp2 struct byte-offset map, indexed
+// by (hw_reg >> 1). 0xFFFF marks a reserved/unmapped hardware slot. Generated
+// from the struct in vdp2.h and validated against a real 0.9.15 savestate
+// (RAMCTL, priorities, scroll, color offsets all read correctly). The three
+// regions: hw < 0x0C maps 1:1; 0x0E..0x76 is hw-2 (the struct omits the
+// reserved word at 0x0C); 0x78..0x11E maps 1:1 again (the u32 zoom/address
+// unions insert padding that re-absorbs the shift), but each u32's two 16-bit
+// halves are byte-swapped for the little-endian host that wrote the state.
+const uint16_t kVdp2RegStructOffset[144] =
+{
+    0x000, 0x002, 0x004, 0x006, 0x008, 0x00A, 0xFFFF, 0x00C,   // hw 0x000
+    0x00E, 0x010, 0x012, 0x014, 0x016, 0x018, 0x01A, 0x01C,   // hw 0x010
+    0x01E, 0x020, 0x022, 0x024, 0x026, 0x028, 0x02A, 0x02C,   // hw 0x020
+    0x02E, 0x030, 0x032, 0x034, 0x036, 0x038, 0x03A, 0x03C,   // hw 0x030
+    0x03E, 0x040, 0x042, 0x044, 0x046, 0x048, 0x04A, 0x04C,   // hw 0x040
+    0x04E, 0x050, 0x052, 0x054, 0x056, 0x058, 0x05A, 0x05C,   // hw 0x050
+    0x05E, 0x060, 0x062, 0x064, 0x066, 0x068, 0x06A, 0x06C,   // hw 0x060
+    0x06E, 0x070, 0x072, 0x074, 0x07A, 0x078, 0x07E, 0x07C,   // hw 0x070
+    0x080, 0x082, 0x084, 0x086, 0x08A, 0x088, 0x08E, 0x08C,   // hw 0x080
+    0x090, 0x092, 0x094, 0x096, 0x098, 0x09A, 0x09E, 0x09C,   // hw 0x090
+    0x0A2, 0x0A0, 0x0A6, 0x0A4, 0x0AA, 0x0A8, 0x0AC, 0x0AE,   // hw 0x0A0
+    0x0B0, 0x0B2, 0x0B4, 0x0B6, 0x0B8, 0x0BA, 0x0BE, 0x0BC,   // hw 0x0B0
+    0x0C0, 0x0C2, 0x0C4, 0x0C6, 0x0C8, 0x0CA, 0x0CC, 0x0CE,   // hw 0x0C0
+    0x0D0, 0x0D2, 0x0D4, 0x0D6, 0x0DA, 0x0D8, 0x0DE, 0x0DC,   // hw 0x0D0
+    0x0E0, 0x0E2, 0x0E4, 0x0E6, 0x0E8, 0x0EA, 0x0EC, 0x0EE,   // hw 0x0E0
+    0x0F0, 0x0F2, 0x0F4, 0x0F6, 0x0F8, 0x0FA, 0x0FC, 0xFFFF,   // hw 0x0F0
+    0x0FE, 0x100, 0x102, 0x104, 0x106, 0x108, 0x10A, 0x10C,   // hw 0x100
+    0x10E, 0x110, 0x112, 0x114, 0x116, 0x118, 0x11A, 0x11C,   // hw 0x110
+};
+}  // namespace
+
+uint16_t ReadReg16(const std::vector<uint8_t>& regs, uint32_t reg)
+{
+    if (reg + 1 >= regs.size())
+    {
+        return 0;
+    }
+    return static_cast<uint16_t>((regs[reg] << 8) | regs[reg + 1]);
+}
+
+void BuildVdp2RegImage(const std::vector<uint8_t>& src, size_t structBase,
+                       std::vector<uint8_t>& out)
+{
+    out.assign(kVdp2RegMax + 2, 0);
+    for (uint32_t hw = 0; hw <= kVdp2RegMax; hw += 2)
+    {
+        const uint16_t so = kVdp2RegStructOffset[hw >> 1];
+        if (so == 0xFFFF || structBase + so + 1 >= src.size())
+        {
+            continue;  // reserved slot, or beyond the section
+        }
+        const uint16_t val = static_cast<uint16_t>(src[structBase + so] |
+                                                   (src[structBase + so + 1] << 8));
+        out[hw]     = static_cast<uint8_t>(val >> 8);
+        out[hw + 1] = static_cast<uint8_t>(val & 0xFF);
+    }
+}
+
+void NormalizeCramToBigEndian(std::vector<uint8_t>& cram, unsigned crmd)
+{
+    const size_t step = (crmd == 2) ? 4 : 2;   // mode 2 = RGB888 (32-bit entries)
+    for (size_t i = 0; i + step <= cram.size(); i += step)
+    {
+        for (size_t a = 0, b = step - 1; a < b; ++a, --b)
+        {
+            const uint8_t t = cram[i + a];
+            cram[i + a] = cram[i + b];
+            cram[i + b] = t;
+        }
+    }
+}
+
+}  // namespace sedrv

--- a/SaturnExplorer/Drivers/Common/src/SaturnStateShared.h
+++ b/SaturnExplorer/Drivers/Common/src/SaturnStateShared.h
@@ -1,0 +1,34 @@
+// Shared Saturn-state helpers used by more than one driver (savestate + live):
+// big-endian register reads, the Yabause VDP2 register-image reconstruction, and
+// CRAM endian normalization. Kept in one place so the savestate and live drivers
+// can't drift apart on the (fixed, hardware-defined) VDP2 struct layout.
+#ifndef SATURNEXPLORER_DRIVER_SATURNSTATESHARED_H
+#define SATURNEXPLORER_DRIVER_SATURNSTATESHARED_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace sedrv
+{
+
+// Big-endian 16-bit read from a hardware-offset register image (Saturn is BE).
+// Returns 0 if the offset is out of range.
+uint16_t ReadReg16(const std::vector<uint8_t>& regs, uint32_t reg);
+
+// Rebuild a hardware-offset, big-endian VDP2 register image from the packed
+// (little-endian, host-order) Yabause `Vdp2` struct that starts at 'structBase'
+// in 'src'. The core's read_vdp2_reg reads big-endian at hardware offsets, so
+// this image is directly usable. 'out' is sized to cover every VDP2 register.
+void BuildVdp2RegImage(const std::vector<uint8_t>& src, size_t structBase,
+                       std::vector<uint8_t>& out);
+
+// Normalize host-endian VDP2 color RAM to Saturn-native big-endian, in place.
+// Yabause keeps CRAM in host byte order (T2 access); the core (like hardware and
+// VRAM) expects big-endian. 'crmd' is RAMCTL bits 12-13 (2 = RGB888 => 32-bit
+// entries, otherwise 16-bit).
+void NormalizeCramToBigEndian(std::vector<uint8_t>& cram, unsigned crmd);
+
+}  // namespace sedrv
+
+#endif /* SATURNEXPLORER_DRIVER_SATURNSTATESHARED_H */

--- a/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
+++ b/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
@@ -1,0 +1,43 @@
+/* Saturn Explorer — live-tap wire protocol, shared by the LiveDriver (client)
+ * and the Yabause se_export module (server) so they can't drift.
+ *
+ * Transport: a local stream socket (Unix domain socket on POSIX, named pipe on
+ * Windows). Request/response, one snapshot per request:
+ *
+ *   client -> server : the 4 bytes "GET\n"
+ *   server -> client : a 28-byte little-endian header, then the payloads in
+ *                      order: VDP1 VRAM, VDP2 VRAM, CRAM, VDP2 struct, VDP1 regs.
+ *
+ * Byte conventions match what the core (and the savestate driver) expect:
+ *   - VDP1/VDP2 VRAM : Saturn-native big-endian (Yabause stores it that way).
+ *   - CRAM           : Yabause host byte order (client normalizes to big-endian).
+ *   - VDP2 struct    : the raw 288-byte Yabause `Vdp2` register struct (client
+ *                      rebuilds the hardware-offset image via BuildVdp2RegImage).
+ *   - VDP1 regs      : a ready hardware-offset, big-endian VDP1 register image
+ *                      (0x18 bytes) the server assembles from its Vdp1 struct.
+ */
+#ifndef SATURNEXPLORER_SE_LIVE_PROTOCOL_H
+#define SATURNEXPLORER_SE_LIVE_PROTOCOL_H
+
+#define SE_LIVE_MAGIC0 'S'
+#define SE_LIVE_MAGIC1 'E'
+#define SE_LIVE_MAGIC2 'X'
+#define SE_LIVE_MAGIC3 'P'
+#define SE_LIVE_VERSION      1u
+#define SE_LIVE_REQUEST      "GET\n"
+#define SE_LIVE_REQUEST_LEN  4
+#define SE_LIVE_HEADER_LEN   28   /* magic(4) + version(4) + 5 section lengths(4 each) */
+
+/* Canonical section sizes (bytes). The header still carries the actual lengths,
+ * so a client validates rather than assumes; these are the expected values. */
+#define SE_LIVE_VDP1_VRAM_LEN   0x80000u
+#define SE_LIVE_VDP2_VRAM_LEN   0x80000u
+#define SE_LIVE_CRAM_LEN        0x1000u
+#define SE_LIVE_VDP2_STRUCT_LEN 288u
+#define SE_LIVE_VDP1_REGS_LEN   0x18u
+
+/* Default endpoints. */
+#define SE_LIVE_DEFAULT_SOCK_PATH "/tmp/saturn_explorer.sock"
+#define SE_LIVE_DEFAULT_PIPE_NAME "\\\\.\\pipe\\SaturnExplorer"
+
+#endif /* SATURNEXPLORER_SE_LIVE_PROTOCOL_H */

--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
@@ -1,0 +1,326 @@
+// LiveDriver — see LiveDriver.h. A background thread polls the patched Yabause
+// for a fresh VDP snapshot; the se_data_source callbacks serve the latest one.
+
+#include "LiveDriver.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <new>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "SaturnStateShared.h"
+#include "SeLiveProtocol.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
+
+namespace
+{
+
+/* ---- One decoded, core-ready frame. All buffers are Saturn-native big-endian
+       and register images are hardware-offset (directly usable by the core). ---- */
+struct LiveSnapshot
+{
+    std::vector<uint8_t> vdp1Vram;
+    std::vector<uint8_t> vdp2Vram;
+    std::vector<uint8_t> cram;
+    std::vector<uint8_t> vdp2Regs;   // hw-offset BE image
+    std::vector<uint8_t> vdp1Regs;   // hw-offset BE image
+    bool                 valid = false;
+};
+
+struct LiveState
+{
+    std::string       endpoint;
+    std::thread       thread;
+    std::atomic<bool> running{false};
+    std::mutex        mtx;           // guards 'front'
+    LiveSnapshot      front;
+};
+
+/* ---- Local-socket transport (POSIX Unix socket / Windows named pipe). ---- */
+struct Conn
+{
+#if defined(_WIN32)
+    HANDLE h = INVALID_HANDLE_VALUE;
+    bool ok() const { return h != INVALID_HANDLE_VALUE; }
+#else
+    int fd = -1;
+    bool ok() const { return fd >= 0; }
+#endif
+};
+
+bool ConnOpen(Conn& c, const char* endpoint)
+{
+#if defined(_WIN32)
+    c.h = CreateFileA(endpoint, GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                      OPEN_EXISTING, 0, nullptr);
+    return c.h != INVALID_HANDLE_VALUE;
+#else
+    c.fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (c.fd < 0)
+    {
+        return false;
+    }
+    sockaddr_un addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, endpoint, sizeof(addr.sun_path) - 1);
+    if (::connect(c.fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+    {
+        ::close(c.fd);
+        c.fd = -1;
+        return false;
+    }
+    return true;
+#endif
+}
+
+void ConnClose(Conn& c)
+{
+#if defined(_WIN32)
+    if (c.h != INVALID_HANDLE_VALUE) { CloseHandle(c.h); c.h = INVALID_HANDLE_VALUE; }
+#else
+    if (c.fd >= 0) { ::close(c.fd); c.fd = -1; }
+#endif
+}
+
+bool ConnWrite(Conn& c, const void* data, size_t size)
+{
+    const uint8_t* p = static_cast<const uint8_t*>(data);
+    size_t done = 0;
+    while (done < size)
+    {
+#if defined(_WIN32)
+        DWORD n = 0;
+        if (!WriteFile(c.h, p + done, static_cast<DWORD>(size - done), &n, nullptr) || n == 0)
+            return false;
+#else
+        ssize_t n = ::send(c.fd, p + done, size - done, 0);
+        if (n <= 0)
+            return false;
+#endif
+        done += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+bool ConnReadFull(Conn& c, void* data, size_t size)
+{
+    uint8_t* p = static_cast<uint8_t*>(data);
+    size_t done = 0;
+    while (done < size)
+    {
+#if defined(_WIN32)
+        DWORD n = 0;
+        if (!ReadFile(c.h, p + done, static_cast<DWORD>(size - done), &n, nullptr) || n == 0)
+            return false;
+#else
+        ssize_t n = ::recv(c.fd, p + done, size - done, 0);
+        if (n <= 0)
+            return false;
+#endif
+        done += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+uint32_t Rd32LE(const uint8_t* p)
+{
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+// Read one snapshot from a connected socket into 'snap' (converted to core-ready
+// form). Returns false on any protocol/socket error.
+bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
+{
+    if (!ConnWrite(c, SE_LIVE_REQUEST, SE_LIVE_REQUEST_LEN))
+    {
+        return false;
+    }
+    uint8_t hdr[SE_LIVE_HEADER_LEN];
+    if (!ConnReadFull(c, hdr, sizeof(hdr)))
+    {
+        return false;
+    }
+    if (hdr[0] != SE_LIVE_MAGIC0 || hdr[1] != SE_LIVE_MAGIC1 ||
+        hdr[2] != SE_LIVE_MAGIC2 || hdr[3] != SE_LIVE_MAGIC3)
+    {
+        return false;
+    }
+    // hdr[4..7] version (unused beyond presence for now)
+    const uint32_t v1 = Rd32LE(hdr + 8);
+    const uint32_t v2 = Rd32LE(hdr + 12);
+    const uint32_t cr = Rd32LE(hdr + 16);
+    const uint32_t vs = Rd32LE(hdr + 20);
+    const uint32_t vr = Rd32LE(hdr + 24);
+    // Sanity clamps so a malformed header can't drive a huge allocation.
+    if (v1 > 0x100000u || v2 > 0x100000u || cr > 0x4000u || vs > 4096u || vr > 256u)
+    {
+        return false;
+    }
+
+    snap.vdp1Vram.resize(v1);
+    snap.vdp2Vram.resize(v2);
+    snap.cram.resize(cr);
+    std::vector<uint8_t> vdp2Struct(vs);
+    snap.vdp1Regs.resize(vr);
+    if (!ConnReadFull(c, snap.vdp1Vram.data(), v1) ||
+        !ConnReadFull(c, snap.vdp2Vram.data(), v2) ||
+        !ConnReadFull(c, snap.cram.data(), cr) ||
+        !ConnReadFull(c, vdp2Struct.data(), vs) ||
+        !ConnReadFull(c, snap.vdp1Regs.data(), vr))
+    {
+        return false;
+    }
+
+    // VRAM is already big-endian; build the VDP2 register image and use RAMCTL's
+    // CRAM mode to normalize CRAM — exactly like the savestate path.
+    sedrv::BuildVdp2RegImage(vdp2Struct, 0, snap.vdp2Regs);
+    const uint16_t ramctl = sedrv::ReadReg16(snap.vdp2Regs, 0x0E);
+    sedrv::NormalizeCramToBigEndian(snap.cram, (ramctl >> 12) & 0x3u);
+    snap.valid = true;
+    return true;
+}
+
+void PollLoop(LiveState* st)
+{
+    Conn conn;
+    while (st->running.load())
+    {
+        if (!conn.ok())
+        {
+            if (!ConnOpen(conn, st->endpoint.c_str()))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(250));
+                continue;
+            }
+        }
+        LiveSnapshot snap;
+        if (!ReadSnapshot(conn, snap))
+        {
+            ConnClose(conn);   // will reconnect next iteration
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            continue;
+        }
+        {
+            std::lock_guard<std::mutex> lk(st->mtx);
+            st->front = std::move(snap);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(8));   // ~120 Hz cap
+    }
+    ConnClose(conn);
+}
+
+size_t CopyRegion(const std::vector<uint8_t>& buf, uint32_t off, void* dst, size_t size)
+{
+    if (off >= buf.size())
+    {
+        return 0;
+    }
+    const size_t avail = buf.size() - off;
+    const size_t n = size < avail ? size : avail;
+    std::memcpy(dst, buf.data() + off, n);
+    return n;
+}
+
+/* ---- se_data_source callbacks ---- */
+LiveState* St(void* user) { return static_cast<LiveState*>(user); }
+
+size_t CbVdp1Vram(void* u, uint32_t off, void* dst, size_t size)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    return CopyRegion(st->front.vdp1Vram, off, dst, size);
+}
+size_t CbVdp2Vram(void* u, uint32_t off, void* dst, size_t size)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    return CopyRegion(st->front.vdp2Vram, off, dst, size);
+}
+size_t CbCram(void* u, uint32_t off, void* dst, size_t size)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    return CopyRegion(st->front.cram, off, dst, size);
+}
+size_t CbMainRam(void* u, uint32_t, void*, size_t) { (void)u; return 0; }
+
+uint16_t CbVdp1Reg(void* u, uint32_t reg)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    return sedrv::ReadReg16(st->front.vdp1Regs, reg);
+}
+uint16_t CbVdp2Reg(void* u, uint32_t reg)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    return sedrv::ReadReg16(st->front.vdp2Regs, reg);
+}
+
+void CbClose(void* u)
+{
+    LiveState* st = St(u);
+    if (!st) { return; }
+    st->running.store(false);
+    if (st->thread.joinable()) { st->thread.join(); }
+    delete st;
+}
+
+}  // namespace
+
+extern "C" se_result se_live_open(const char* endpoint, se_data_source* out)
+{
+    if (!out)
+    {
+        return SE_ERR_INVALID_ARG;
+    }
+    std::memset(out, 0, sizeof(*out));
+
+    const char* ep = endpoint;
+    if (!ep || !ep[0])
+    {
+#if defined(_WIN32)
+        ep = SE_LIVE_DEFAULT_PIPE_NAME;
+#else
+        ep = SE_LIVE_DEFAULT_SOCK_PATH;
+#endif
+    }
+
+    // Fail fast if the emulator isn't reachable right now.
+    Conn probe;
+    if (!ConnOpen(probe, ep))
+    {
+        return SE_ERR_IO;
+    }
+    ConnClose(probe);
+
+    LiveState* st = new (std::nothrow) LiveState();
+    if (!st)
+    {
+        return SE_ERR_NO_DATA;
+    }
+    st->endpoint = ep;
+    st->running.store(true);
+    st->thread = std::thread(PollLoop, st);
+
+    out->abi_version = SE_ABI_VERSION;
+    out->capabilities = SE_CAP_VDP1_VRAM | SE_CAP_VDP2_VRAM | SE_CAP_CRAM |
+                        SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS;
+    out->user = st;
+    out->read_vdp1_vram = CbVdp1Vram;
+    out->read_vdp2_vram = CbVdp2Vram;
+    out->read_cram      = CbCram;
+    out->read_main_ram  = CbMainRam;
+    out->read_vdp1_reg  = CbVdp1Reg;
+    out->read_vdp2_reg  = CbVdp2Reg;
+    out->close          = CbClose;
+    return SE_OK;
+}

--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.h
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.h
@@ -1,0 +1,25 @@
+/* Saturn Explorer — Live driver (Seam A). Connects to a running, patched Yabause
+ * over a local socket (see SeLiveProtocol.h) and serves its VDP state to the core
+ * as an se_data_source, refreshed on a background thread. Native only (threads +
+ * sockets) — not part of the WASM/web build.
+ */
+#ifndef SATURNEXPLORER_LIVE_DRIVER_H
+#define SATURNEXPLORER_LIVE_DRIVER_H
+
+#include "saturnexplorer/SeDataSource.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Open a live connection. 'endpoint' is the local socket path (POSIX) or named
+ * pipe (Windows); pass NULL for the platform default (SE_LIVE_DEFAULT_*). On
+ * success returns SE_OK and fills '*out' (whose 'close' stops the poll thread on
+ * se_destroy). Returns SE_ERR_IO if the emulator isn't reachable. */
+se_result se_live_open(const char* endpoint, se_data_source* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SATURNEXPLORER_LIVE_DRIVER_H */

--- a/SaturnExplorer/Drivers/Savestate/src/SavestateDriver.cpp
+++ b/SaturnExplorer/Drivers/Savestate/src/SavestateDriver.cpp
@@ -5,8 +5,13 @@
 #include <string>
 #include <vector>
 
+#include "SaturnStateShared.h"
+
 namespace
 {
+using sedrv::BuildVdp2RegImage;
+using sedrv::NormalizeCramToBigEndian;
+using sedrv::ReadReg16;
 
 // Documented absolute bus addresses (Docs/Saturn/MemoryLayout.txt).
 constexpr uint32_t kAddrVdp1Vram = 0x05C00000u;
@@ -50,16 +55,6 @@ size_t ReadRegion(const std::vector<uint8_t>& buffer, uint32_t offset,
     size_t count = size < avail ? size : avail;
     std::memcpy(dst, buffer.data() + offset, count);
     return count;
-}
-
-// Big-endian 16-bit register read (Saturn is big-endian).
-uint16_t ReadReg16(const std::vector<uint8_t>& regs, uint32_t reg)
-{
-    if (reg + 1 >= regs.size())
-    {
-        return 0;
-    }
-    return static_cast<uint16_t>((regs[reg] << 8) | regs[reg + 1]);
 }
 
 /* --- Seam A callbacks --- */
@@ -206,7 +201,6 @@ namespace
 constexpr uint32_t kVramSize    = 0x80000;   // VDP1/VDP2 VRAM
 constexpr uint32_t kYssCramSize = 0x1000;    // VDP2 color RAM
 constexpr uint32_t kVdp2RegSize = 288;       // sizeof(Vdp2): 286 regs + 2 padding to u32 align
-constexpr uint32_t kVdp2RegMax  = 0x11E;     // highest VDP2 register (COBB)
 constexpr size_t   kYssHeaderSize = 0x14;    // file header before the first section
 
 // The classic Yabause Vdp2 register struct is a fixed hardware mirror (TVMD..COBB,
@@ -222,77 +216,6 @@ uint32_t Read32LE(const std::vector<uint8_t>& d, size_t o)
 {
     return static_cast<uint32_t>(d[o]) | (static_cast<uint32_t>(d[o + 1]) << 8) |
            (static_cast<uint32_t>(d[o + 2]) << 16) | (static_cast<uint32_t>(d[o + 3]) << 24);
-}
-
-// Exact hardware-offset -> Yabause 0.9.15 Vdp2 struct byte-offset map, indexed
-// by (hw_reg >> 1). 0xFFFF marks a reserved/unmapped hardware slot. Generated
-// from the struct in vdp2.h and validated against a real 0.9.15 savestate
-// (RAMCTL, priorities, scroll, color offsets all read correctly). The three
-// regions: hw < 0x0C maps 1:1; 0x0E..0x76 is hw-2 (the struct omits the
-// reserved word at 0x0C); 0x78..0x11E maps 1:1 again (the u32 zoom/address
-// unions insert padding that re-absorbs the shift), but each u32's two 16-bit
-// halves are byte-swapped for the little-endian host that wrote the state.
-const uint16_t kVdp2RegStructOffset[144] =
-{
-    0x000, 0x002, 0x004, 0x006, 0x008, 0x00A, 0xFFFF, 0x00C,   // hw 0x000
-    0x00E, 0x010, 0x012, 0x014, 0x016, 0x018, 0x01A, 0x01C,   // hw 0x010
-    0x01E, 0x020, 0x022, 0x024, 0x026, 0x028, 0x02A, 0x02C,   // hw 0x020
-    0x02E, 0x030, 0x032, 0x034, 0x036, 0x038, 0x03A, 0x03C,   // hw 0x030
-    0x03E, 0x040, 0x042, 0x044, 0x046, 0x048, 0x04A, 0x04C,   // hw 0x040
-    0x04E, 0x050, 0x052, 0x054, 0x056, 0x058, 0x05A, 0x05C,   // hw 0x050
-    0x05E, 0x060, 0x062, 0x064, 0x066, 0x068, 0x06A, 0x06C,   // hw 0x060
-    0x06E, 0x070, 0x072, 0x074, 0x07A, 0x078, 0x07E, 0x07C,   // hw 0x070
-    0x080, 0x082, 0x084, 0x086, 0x08A, 0x088, 0x08E, 0x08C,   // hw 0x080
-    0x090, 0x092, 0x094, 0x096, 0x098, 0x09A, 0x09E, 0x09C,   // hw 0x090
-    0x0A2, 0x0A0, 0x0A6, 0x0A4, 0x0AA, 0x0A8, 0x0AC, 0x0AE,   // hw 0x0A0
-    0x0B0, 0x0B2, 0x0B4, 0x0B6, 0x0B8, 0x0BA, 0x0BE, 0x0BC,   // hw 0x0B0
-    0x0C0, 0x0C2, 0x0C4, 0x0C6, 0x0C8, 0x0CA, 0x0CC, 0x0CE,   // hw 0x0C0
-    0x0D0, 0x0D2, 0x0D4, 0x0D6, 0x0DA, 0x0D8, 0x0DE, 0x0DC,   // hw 0x0D0
-    0x0E0, 0x0E2, 0x0E4, 0x0E6, 0x0E8, 0x0EA, 0x0EC, 0x0EE,   // hw 0x0E0
-    0x0F0, 0x0F2, 0x0F4, 0x0F6, 0x0F8, 0x0FA, 0x0FC, 0xFFFF,   // hw 0x0F0
-    0x0FE, 0x100, 0x102, 0x104, 0x106, 0x108, 0x10A, 0x10C,   // hw 0x100
-    0x10E, 0x110, 0x112, 0x114, 0x116, 0x118, 0x11A, 0x11C,   // hw 0x110
-};
-
-// Rebuild a hardware-offset, big-endian VDP2 register image from the packed
-// little-endian Vdp2 struct that starts at 'structBase' in 'file'. The shared
-// read_vdp2_reg reads big-endian at hardware offsets, so this lets the core use
-// it unchanged. 'out' is sized to cover every register up to kVdp2RegMax.
-void BuildVdp2RegImage(const std::vector<uint8_t>& file, size_t structBase,
-                       std::vector<uint8_t>& out)
-{
-    out.assign(kVdp2RegMax + 2, 0);
-    for (uint32_t hw = 0; hw <= kVdp2RegMax; hw += 2)
-    {
-        const uint16_t so = kVdp2RegStructOffset[hw >> 1];
-        if (so == 0xFFFF || structBase + so + 1 >= file.size())
-        {
-            continue;  // reserved slot, or beyond the section
-        }
-        const uint16_t val = static_cast<uint16_t>(file[structBase + so] |
-                                                   (file[structBase + so + 1] << 8));
-        out[hw]     = static_cast<uint8_t>(val >> 8);
-        out[hw + 1] = static_cast<uint8_t>(val & 0xFF);
-    }
-}
-
-// Yabause keeps VDP2 color RAM in host-native byte order (T2 access), so a
-// savestate written on a little-endian host stores it little-endian, whereas
-// the core (like real Saturn hardware and VRAM) expects big-endian. Normalize
-// in place: swap 16-bit entries for the RGB555 modes, 32-bit for RGB888. 'crmd'
-// is RAMCTL bits 12-13.
-void NormalizeCramToBigEndian(std::vector<uint8_t>& cram, unsigned crmd)
-{
-    const size_t step = (crmd == 2) ? 4 : 2;   // mode 2 = RGB888 (32-bit entries)
-    for (size_t i = 0; i + step <= cram.size(); i += step)
-    {
-        for (size_t a = 0, b = step - 1; a < b; ++a, --b)
-        {
-            const uint8_t t = cram[i + a];
-            cram[i + a] = cram[i + b];
-            cram[i + b] = t;
-        }
-    }
 }
 
 /* --- Mednafen MDFNSVST (Saturn 'ss' module) savestate --- */

--- a/SaturnExplorer/FrontEnd/Platforms/Web/WebMain.cpp
+++ b/SaturnExplorer/FrontEnd/Platforms/Web/WebMain.cpp
@@ -14,6 +14,7 @@
 #include <emscripten.h>
 #else
 #include <cstdio>
+#include <cstring>
 #include <vector>
 #endif
 
@@ -82,9 +83,13 @@ int main(int argc, char** argv)
     // main() does not return and tear down the context.
     emscripten_set_main_loop(FrameOnce, 0, 1);
 #else
-    // Native (desktop) convenience: load a savestate/dump passed on the command
-    // line, since there is no browser file picker here.
-    if (argc > 1)
+    // Native (desktop) convenience: `--live [endpoint]` connects to a running
+    // Yabause; otherwise a savestate/dump path loads it (no browser picker here).
+    if (argc > 1 && std::strcmp(argv[1], "--live") == 0)
+    {
+        gApp.OpenLive(argc > 2 ? argv[2] : nullptr);
+    }
+    else if (argc > 1)
     {
         if (FILE* f = std::fopen(argv[1], "rb"))
         {

--- a/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
+++ b/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
@@ -4,6 +4,9 @@
 // the portable App class.
 #include <windows.h>
 
+#include <cstdlib>   // __argc / __argv
+#include <cstring>
+
 #include "WindowsPlatform.h"
 #include "App.h"
 
@@ -18,6 +21,17 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
 
     sfe::App app;
     app.Initialize();
+
+    // `--live [endpoint]` connects to a running Yabause on startup (see the
+    // Integration/Yabause module). Otherwise the user opens files from the toolbar.
+    for (int i = 1; i < __argc; ++i)
+    {
+        if (std::strcmp(__argv[i], "--live") == 0)
+        {
+            app.OpenLive((i + 1 < __argc) ? __argv[i + 1] : nullptr);
+            break;
+        }
+    }
 
     while (platform.PumpEvents())
     {

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -10,6 +10,9 @@
 
 #include "Platform/IPlatform.h"
 #include "SavestateDriver.h"
+#ifdef SE_ENABLE_LIVE
+#include "LiveDriver.h"   // native builds only (threads/sockets)
+#endif
 
 namespace sfe
 {
@@ -132,6 +135,7 @@ void App::CloseData()
         mContext = nullptr;
     }
     mbHasData = false;
+    mbLiveSource = false;
     mSelectedCommand = -1;
     mSelection.clear();
     // The frame texture is freed lazily (on next size change) or with the
@@ -284,6 +288,29 @@ bool App::OpenSavestate(const char* path)
     return true;
 }
 
+bool App::OpenLive(const char* endpoint)
+{
+#ifdef SE_ENABLE_LIVE
+    CloseData();
+    se_data_source dataSource;
+    if (se_live_open(endpoint, &dataSource) != SE_OK)
+    {
+        return false;
+    }
+    if (!CreateContextFromSource(dataSource, &mContext))
+    {
+        return false;
+    }
+    mDataSource = dataSource;
+    mbHasData = true;
+    mbLiveSource = true;   // re-snapshot every frame (see BuildUI)
+    return true;
+#else
+    (void)endpoint;
+    return false;
+#endif
+}
+
 bool App::OpenSavestateBuffer(const uint8_t* data, size_t size)
 {
     CloseData();
@@ -305,6 +332,14 @@ bool App::OpenSavestateBuffer(const uint8_t* data, size_t size)
 
 void App::BuildUI(IPlatform& platform)
 {
+    // A live source changes every frame: re-snapshot before anything reads it, so
+    // all panels reflect the running emulator's current VDP state. (Static sources
+    // snapshot once at load, in CreateContextFromSource.)
+    if (mbLiveSource && mContext)
+    {
+        se_begin_frame(mContext);
+    }
+
     if (mbHasData)
     {
         RenderFrameToTexture(platform);
@@ -456,6 +491,14 @@ void App::DrawToolbar(IPlatform& platform)
                 std::string path;
                 if (platform.OpenFileDialog(path)) OpenFullDump(path.c_str(), 0x00000000u);
             }
+#ifdef SE_ENABLE_LIVE
+            ImGui::Separator();
+            if (ImGui::MenuItem("Connect to Yabause (live)", nullptr, false, !mbLiveSource))
+            {
+                OpenLive(nullptr);   // default local socket / named pipe
+            }
+            if (ImGui::MenuItem("Disconnect (live)", nullptr, false, mbLiveSource)) CloseData();
+#endif
             if (ImGui::MenuItem("Close", nullptr, false, mbHasData)) CloseData();
             ImGui::EndPopup();
         }

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -30,6 +30,11 @@ public:
     // context. Used by the web build, where files arrive as bytes from JS.
     bool OpenSavestateBuffer(const uint8_t* data, size_t size);
 
+    // Connect to a running, patched Yabause (live source). 'endpoint' may be NULL
+    // for the platform default socket. No-op returning false unless the build was
+    // compiled with the LiveDriver (SE_ENABLE_LIVE — native desktop / Windows).
+    bool OpenLive(const char* endpoint);
+
     // Draw the whole UI. Called once per frame, between the platform's
     // BeginFrame and EndFrame.
     void BuildUI(IPlatform& platform);
@@ -68,6 +73,7 @@ private:
     bool           mbHasData = false;
 
     se_render_opts   mRenderOpts {};
+    bool             mbLiveSource = false;    // data comes from a running emulator
     int              mSelectedCommand = -1;   // primary selection (detail panels)
     std::vector<int> mSelection;              // all selected command indices
     bool             mbLayoutBuilt = false;   // default dock layout applied once

--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -1,0 +1,73 @@
+# Yabause live-tap integration
+
+This lets Saturn Explorer read a **running** Yabause in realtime: Yabause runs a
+tiny local-socket server that streams its VDP1/VDP2 VRAM, CRAM, and VDP2 registers
+each frame; Saturn Explorer's **LiveDriver** connects and updates every panel live.
+
+It's a small, isolated patch to Yabause — one new module plus three one-line hook
+calls. It does not touch emulation logic, so it can't affect game compatibility.
+
+## 1. Copy three files into `yabause/src`
+- `se_export.h`
+- `se_export.c`
+- `SeLiveProtocol.h`  ← from this repo's `Drivers/Common/src/SeLiveProtocol.h`
+  (kept single-source there so the server and the client never drift)
+
+Add `se_export.c` to Yabause's build (its `src/CMakeLists.txt` `yabause_SOURCES`
+list, or your Makefile). On Windows link against `ws2_32` if it isn't already.
+
+## 2. Wire in three calls
+In `yabause/src/yabause.c`:
+
+```c
+#include "se_export.h"
+
+int YabauseInit(yabauseinit_struct *init) {
+    /* ... existing init ... */
+    SeExportInit();                 /* add at the very end, before `return 0;` */
+    return 0;
+}
+
+void YabauseDeInit(void) {
+    SeExportDeinit();               /* add near the top */
+    /* ... existing deinit ... */
+}
+```
+
+In `yabause/src/vdp2.c`, at the end of `Vdp2VBlankOUT(void)` (fires once per
+frame, after the frame is drawn):
+
+```c
+#include "se_export.h"
+    /* ... existing VBlankOUT body ... */
+    SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs);
+```
+
+`Vdp1Ram`, `Vdp2Ram`, `Vdp2ColorRam` are Yabause's VDP RAM globals; `Vdp2Regs` is
+its `Vdp2*` register struct. (These names are stable across the Yabause family. If
+your fork renamed them, pass the equivalents — the module just needs the four
+pointers.) That's the whole patch.
+
+## 3. Build & run
+1. Build Yabause as usual (the port you use for Sakura Wars, etc.).
+2. Launch it and load the game.
+3. Launch Saturn Explorer and click **Connect to Yabause** (or start it with
+   `--live` to auto-connect). Everything — VDP Output, VRAM Map, command list,
+   registers, textures — now tracks the running game.
+
+## What flows over the wire
+Per request, the server sends: VDP1 VRAM (512 KiB), VDP2 VRAM (512 KiB), CRAM
+(4 KiB), and the 288-byte VDP2 register struct — the exact bytes Saturn Explorer's
+savestate loader already understands (VRAM big-endian, CRAM host-endian, VDP2 the
+raw struct). Wire format: `Drivers/Common/src/SeLiveProtocol.h`.
+
+## Notes / limits (v1)
+- **Transport:** Unix domain socket `/tmp/saturn_explorer.sock` (Linux/macOS) or
+  named pipe `\\.\pipe\SaturnExplorer` (Windows). Local only.
+- **VDP1 registers** aren't streamed yet (most VDP1 draw state lives in the command
+  table, which *is* streamed via VDP1 VRAM). The wire format reserves a slot; to add
+  them, assemble a 0x18-byte big-endian image from Yabause's `Vdp1Regs` fields and
+  send it in place of the current zero-length section.
+- **Work RAM / disc / frame-step** aren't exported yet; easy follow-ons.
+- The snapshot is taken at vblank under a lock and double-buffered, so the client
+  always reads a whole, consistent frame.

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -1,0 +1,212 @@
+/* Saturn Explorer — Yabause memory-export server. See se_export.h + README.md.
+ * Self-contained: only needs SeLiveProtocol.h (copy it in from
+ * Drivers/Common/src/) and the platform's sockets/threads. */
+
+#include "se_export.h"
+#include "SeLiveProtocol.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
+
+#define SE_V1 SE_LIVE_VDP1_VRAM_LEN
+#define SE_V2 SE_LIVE_VDP2_VRAM_LEN
+#define SE_CR SE_LIVE_CRAM_LEN
+#define SE_VS SE_LIVE_VDP2_STRUCT_LEN
+
+typedef struct
+{
+    unsigned char v1[SE_V1];
+    unsigned char v2[SE_V2];
+    unsigned char cr[SE_CR];
+    unsigned char vs[SE_VS];
+    int valid;
+} SeFrame;
+
+static SeFrame* sFront;
+static SeFrame* sBack;
+static volatile int sRunning;
+
+#if defined(_WIN32)
+static HANDLE sThread;
+static CRITICAL_SECTION sLock;
+#define SE_LOCK()   EnterCriticalSection(&sLock)
+#define SE_UNLOCK() LeaveCriticalSection(&sLock)
+#else
+static pthread_t sThread;
+static pthread_mutex_t sLock = PTHREAD_MUTEX_INITIALIZER;
+static int sListenFd = -1;
+#define SE_LOCK()   pthread_mutex_lock(&sLock)
+#define SE_UNLOCK() pthread_mutex_unlock(&sLock)
+#endif
+
+static void SeWr32(unsigned char* p, unsigned int v)
+{
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+    p[2] = (unsigned char)((v >> 16) & 0xFF);
+    p[3] = (unsigned char)((v >> 24) & 0xFF);
+}
+
+void SeExportSnapshot(const void* vdp1, const void* vdp2, const void* cram, const void* vdp2struct)
+{
+    if (!sBack)
+    {
+        return;
+    }
+    SE_LOCK();
+    if (vdp1) memcpy(sBack->v1, vdp1, SE_V1); else memset(sBack->v1, 0, SE_V1);
+    if (vdp2) memcpy(sBack->v2, vdp2, SE_V2); else memset(sBack->v2, 0, SE_V2);
+    if (cram) memcpy(sBack->cr, cram, SE_CR); else memset(sBack->cr, 0, SE_CR);
+    if (vdp2struct) memcpy(sBack->vs, vdp2struct, SE_VS); else memset(sBack->vs, 0, SE_VS);
+    sBack->valid = 1;
+    {
+        SeFrame* tmp = sFront; sFront = sBack; sBack = tmp;   /* swap */
+    }
+    SE_UNLOCK();
+}
+
+/* ---- Blocking, exact-length socket I/O (0 = success). ---- */
+#if defined(_WIN32)
+static int SeSend(HANDLE h, const void* d, size_t n)
+{
+    const unsigned char* p = (const unsigned char*)d; DWORD w;
+    while (n) { if (!WriteFile(h, p, (DWORD)n, &w, NULL) || w == 0) return -1; p += w; n -= w; }
+    return 0;
+}
+static int SeRecv(HANDLE h, void* d, size_t n)
+{
+    unsigned char* p = (unsigned char*)d; DWORD r;
+    while (n) { if (!ReadFile(h, p, (DWORD)n, &r, NULL) || r == 0) return -1; p += r; n -= r; }
+    return 0;
+}
+#else
+static int SeSend(int fd, const void* d, size_t n)
+{
+    const unsigned char* p = (const unsigned char*)d;
+    while (n) { ssize_t w = send(fd, p, n, 0); if (w <= 0) return -1; p += w; n -= (size_t)w; }
+    return 0;
+}
+static int SeRecv(int fd, void* d, size_t n)
+{
+    unsigned char* p = (unsigned char*)d;
+    while (n) { ssize_t r = recv(fd, p, n, 0); if (r <= 0) return -1; p += r; n -= (size_t)r; }
+    return 0;
+}
+#endif
+
+/* Serve one connected client until it disconnects or the server stops. 'snap' is
+ * scratch the size of one frame. */
+#if defined(_WIN32)
+static void SeServeClient(HANDLE cl, SeFrame* snap)
+#else
+static void SeServeClient(int cl, SeFrame* snap)
+#endif
+{
+    while (sRunning)
+    {
+        char req[SE_LIVE_REQUEST_LEN];
+        if (SeRecv(cl, req, SE_LIVE_REQUEST_LEN) != 0) return;
+        SE_LOCK(); memcpy(snap, sFront, sizeof(SeFrame)); SE_UNLOCK();
+
+        unsigned char hdr[SE_LIVE_HEADER_LEN];
+        hdr[0] = SE_LIVE_MAGIC0; hdr[1] = SE_LIVE_MAGIC1;
+        hdr[2] = SE_LIVE_MAGIC2; hdr[3] = SE_LIVE_MAGIC3;
+        SeWr32(hdr + 4, SE_LIVE_VERSION);
+        SeWr32(hdr + 8, SE_V1); SeWr32(hdr + 12, SE_V2); SeWr32(hdr + 16, SE_CR);
+        SeWr32(hdr + 20, SE_VS); SeWr32(hdr + 24, 0);   /* no VDP1 regs in v1 */
+        if (SeSend(cl, hdr, sizeof(hdr)) != 0) return;
+        if (SeSend(cl, snap->v1, SE_V1) != 0) return;
+        if (SeSend(cl, snap->v2, SE_V2) != 0) return;
+        if (SeSend(cl, snap->cr, SE_CR) != 0) return;
+        if (SeSend(cl, snap->vs, SE_VS) != 0) return;
+    }
+}
+
+#if defined(_WIN32)
+static DWORD WINAPI SeServerThread(LPVOID arg)
+{
+    SeFrame* snap = (SeFrame*)malloc(sizeof(SeFrame));
+    (void)arg;
+    while (sRunning && snap)
+    {
+        HANDLE pipe = CreateNamedPipeA(SE_LIVE_DEFAULT_PIPE_NAME, PIPE_ACCESS_DUPLEX,
+                                       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                       1, 0, 0, 0, NULL);
+        if (pipe == INVALID_HANDLE_VALUE) break;
+        BOOL ok = ConnectNamedPipe(pipe, NULL) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
+        if (ok) SeServeClient(pipe, snap);
+        DisconnectNamedPipe(pipe);
+        CloseHandle(pipe);
+    }
+    free(snap);
+    return 0;
+}
+#else
+static void* SeServerThread(void* arg)
+{
+    SeFrame* snap = (SeFrame*)malloc(sizeof(SeFrame));
+    struct sockaddr_un addr;
+    int srv = socket(AF_UNIX, SOCK_STREAM, 0);
+    (void)arg;
+    if (srv < 0 || !snap) { free(snap); return NULL; }
+    unlink(SE_LIVE_DEFAULT_SOCK_PATH);
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SE_LIVE_DEFAULT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+    if (bind(srv, (struct sockaddr*)&addr, sizeof(addr)) != 0 || listen(srv, 1) != 0)
+    {
+        close(srv); free(snap); return NULL;
+    }
+    sListenFd = srv;
+    while (sRunning)
+    {
+        int cl = accept(srv, NULL, NULL);
+        if (cl < 0) break;   /* closed on deinit */
+        SeServeClient(cl, snap);
+        close(cl);
+    }
+    close(srv);
+    unlink(SE_LIVE_DEFAULT_SOCK_PATH);
+    free(snap);
+    return NULL;
+}
+#endif
+
+int SeExportInit(void)
+{
+    sFront = (SeFrame*)calloc(1, sizeof(SeFrame));
+    sBack  = (SeFrame*)calloc(1, sizeof(SeFrame));
+    if (!sFront || !sBack) { SeExportDeinit(); return -1; }
+    sRunning = 1;
+#if defined(_WIN32)
+    InitializeCriticalSection(&sLock);
+    sThread = CreateThread(NULL, 0, SeServerThread, NULL, 0, NULL);
+    if (!sThread) { sRunning = 0; return -1; }
+#else
+    if (pthread_create(&sThread, NULL, SeServerThread, NULL) != 0) { sRunning = 0; return -1; }
+#endif
+    return 0;
+}
+
+void SeExportDeinit(void)
+{
+    sRunning = 0;
+#if defined(_WIN32)
+    if (sThread) { WaitForSingleObject(sThread, 1000); CloseHandle(sThread); sThread = NULL; }
+    DeleteCriticalSection(&sLock);
+#else
+    if (sListenFd >= 0) { shutdown(sListenFd, SHUT_RDWR); close(sListenFd); sListenFd = -1; }
+    pthread_join(sThread, NULL);
+#endif
+    free(sFront); sFront = NULL;
+    free(sBack);  sBack = NULL;
+}

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -1,0 +1,42 @@
+/* Saturn Explorer — Yabause memory-export server (drop-in module).
+ *
+ * Add this file + se_export.c + SeLiveProtocol.h to yabause/src, then wire three
+ * calls into Yabause (see README.md):
+ *   - SeExportInit()      at the end of YabauseInit()
+ *   - SeExportSnapshot(...) once per frame, from Vdp2VBlankOUT()
+ *   - SeExportDeinit()    in YabauseDeInit()
+ *
+ * It serves the current VDP1/VDP2 VRAM, CRAM, and VDP2 register struct to Saturn
+ * Explorer's LiveDriver over a local socket (Unix domain socket / named pipe).
+ * It is self-contained: SeExportSnapshot takes raw pointers, so this module needs
+ * none of Yabause's headers or types.
+ */
+#ifndef SE_EXPORT_H
+#define SE_EXPORT_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Start the export server (background thread + local socket). Returns 0 on
+ * success, non-zero on failure (Yabause keeps running either way). */
+int SeExportInit(void);
+
+/* Copy the current VDP memory into the export double-buffer. Call once per frame,
+ * e.g. at the end of Vdp2VBlankOUT(), passing Yabause's globals:
+ *   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs);
+ * Sizes are fixed by the hardware (512 KiB / 512 KiB / 4 KiB / 288 bytes). Any
+ * argument may be NULL (that section is sent as zeros). */
+void SeExportSnapshot(const void* vdp1_vram_512k, const void* vdp2_vram_512k,
+                      const void* cram_4k, const void* vdp2_regs_struct_288);
+
+/* Stop the server thread and free resources. */
+void SeExportDeinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SE_EXPORT_H */


### PR DESCRIPTION
Adds an optional **live data source** so Saturn Explorer can inspect a *running* game, not just a savestate. Two processes — a patched Yabause and our standalone app — connected by a **local socket** (Unix domain socket / Windows named pipe; no network exposure). This is the Seam-A "live driver" the architecture anticipated.

## What's here
- **`Drivers/Common`** — hoisted the shared endian-normalization + VDP2 register-image helpers out of the savestate driver into `SaturnExplorerDriverCommon`, so the live driver reuses the *exact* same conversion (no duplicated 144-entry register-offset table). The savestate driver is byte-for-byte unchanged in behavior.
- **`Drivers/Live`** — `LiveDriver` (`se_data_source`): a background poll thread pulls a fresh snapshot ~120 Hz into a double buffer; the callbacks serve the latest frame; the wire blob is converted with the shared helpers. Native only (threads + sockets) — excluded from the web build.
- **`Integration/Yabause`** — `se_export.{c,h}`, a **self-contained drop-in server** for Yabause (local socket, vblank snapshot, double-buffered), plus a `README` with the ~3-call patch (`YabauseInit` / `Vdp2VBlankOUT` / `YabauseDeInit`) and `SeLiveProtocol.h` (the wire format, single-sourced and shared with the client).
- **Frontend** — an **Open ▸ Connect to Yabause** toolbar item and a **`--live`** launch arg; when live, `se_begin_frame` runs every frame so all panels track the game. Guarded by `SE_ENABLE_LIVE`.
- **CMake** — new Common + Live static libs; `SE_ENABLE_LIVE` + LiveDriver linked into the Windows and desktop-SDL2 frontends only (never Emscripten).

## Verified end-to-end (native, headless)
- **No savestate regression:** golden Battle3 render byte-identical, and buffer-equivalence still holds, after the shared-helper refactor.
- **LiveDriver == savestate:** over a real Unix socket, the LiveDriver produces a context byte-identical to loading the same `.yss` (137 commands, 128 sprites, RAMCTL=0x1100, identical frame).
- **Real server interop:** the actual `se_export.c` server (not a mock) interoperates with the LiveDriver byte-identically.
- **Real frontend, live:** the CMake-built frontend launched with `--live` connected to a mock-Yabause process and rendered Battle3 live (screenshot captured).
- **Web build intact:** the Emscripten single-file build still compiles (Common lib links via the savestate driver; no live driver in web).

## Not yet (easy follow-ons, noted in the README)
VDP1 registers, work RAM, and frame-step aren't streamed yet (the wire format reserves room). The only unexercised piece is the 3 mechanical Yabause hook calls, which you compile on your end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_