### PR TITLE
Live: VDP1 registers + low/high work RAM

### DIFF
--- a/SaturnExplorer/Core/src/Context.h
+++ b/SaturnExplorer/Core/src/Context.h
@@ -254,6 +254,8 @@ public:
         case SE_VRAM_KIND_VDP1_VRAM: src = &mSnapshot.Vdp1Vram(); break;
         case SE_VRAM_KIND_VDP2_VRAM: src = &mSnapshot.Vdp2Vram(); break;
         case SE_VRAM_KIND_CRAM:      src = &mSnapshot.Cram();      break;
+        case SE_VRAM_KIND_WRAM_LOW:  src = &mSnapshot.WramLow();   break;
+        case SE_VRAM_KIND_WRAM_HIGH: src = &mSnapshot.WramHigh();  break;
         default: return 0;
         }
         if (!dst || offset >= src->size())

--- a/SaturnExplorer/Core/src/HardwareSnapshot.cpp
+++ b/SaturnExplorer/Core/src/HardwareSnapshot.cpp
@@ -40,6 +40,8 @@ bool HardwareSnapshot::Capture(const se_data_source& dataSource)
     mVdp1Vram.clear();
     mVdp2Vram.clear();
     mCram.clear();
+    mWramLow.clear();
+    mWramHigh.clear();
     mVdp1Regs.clear();
     mVdp2Regs.clear();
 
@@ -63,6 +65,17 @@ bool HardwareSnapshot::Capture(const se_data_source& dataSource)
         size_t got = ReadAll(dataSource.read_cram, dataSource.user, 0,
                              mCram.data(), mCram.size());
         mCram.resize(got);
+    }
+    // Work RAM: low @ 0x00200000, high @ 0x06000000 (each 1 MiB). read_main_ram is
+    // addressed by bus address, so read from those bases.
+    if ((dataSource.capabilities & SE_CAP_MAIN_RAM) && dataSource.read_main_ram)
+    {
+        mWramLow.resize(kWramSize);
+        mWramLow.resize(ReadAll(dataSource.read_main_ram, dataSource.user,
+                                kWramLowBase, mWramLow.data(), mWramLow.size()));
+        mWramHigh.resize(kWramSize);
+        mWramHigh.resize(ReadAll(dataSource.read_main_ram, dataSource.user,
+                                 kWramHighBase, mWramHigh.data(), mWramHigh.size()));
     }
 
     // Capture the VDP1 register file (0x00..0x1E) if the driver supplies it.

--- a/SaturnExplorer/Core/src/HardwareSnapshot.h
+++ b/SaturnExplorer/Core/src/HardwareSnapshot.h
@@ -11,10 +11,13 @@
 namespace se
 {
 
-// Saturn region sizes (Docs/Saturn/MemoryLayout.txt).
+// Saturn region sizes / bus addresses (Docs/Saturn/MemoryLayout.txt).
 constexpr uint32_t kVdp1VramSize = 512 * 1024;
 constexpr uint32_t kVdp2VramSize = 512 * 1024;
 constexpr uint32_t kCramSize     = 4 * 1024;
+constexpr uint32_t kWramSize     = 1024 * 1024;
+constexpr uint32_t kWramLowBase  = 0x00200000;
+constexpr uint32_t kWramHighBase = 0x06000000;
 
 class HardwareSnapshot
 {
@@ -29,6 +32,8 @@ public:
     const std::vector<uint8_t>& Vdp1Vram() const { return mVdp1Vram; }
     const std::vector<uint8_t>& Vdp2Vram() const { return mVdp2Vram; }
     const std::vector<uint8_t>& Cram() const { return mCram; }
+    const std::vector<uint8_t>& WramLow() const { return mWramLow; }
+    const std::vector<uint8_t>& WramHigh() const { return mWramHigh; }
     se_cram_mode CramMode() const { return mCramMode; }
 
     // True if the driver supplied VDP1 / VDP2 registers.
@@ -52,6 +57,8 @@ private:
     std::vector<uint8_t>  mVdp1Vram;
     std::vector<uint8_t>  mVdp2Vram;
     std::vector<uint8_t>  mCram;
+    std::vector<uint8_t>  mWramLow;    // 0x00200000 (present if SE_CAP_MAIN_RAM)
+    std::vector<uint8_t>  mWramHigh;   // 0x06000000
     std::vector<uint16_t> mVdp1Regs;   // indexed by (hw offset >> 1)
     std::vector<uint16_t> mVdp2Regs;
     se_cram_mode          mCramMode = SE_CRAM_RGB555_1024;

--- a/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
+++ b/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
@@ -5,8 +5,9 @@
  * Windows). Request/response, one snapshot per request:
  *
  *   client -> server : the 4 bytes "GET\n"
- *   server -> client : a 28-byte little-endian header, then the payloads in
- *                      order: VDP1 VRAM, VDP2 VRAM, CRAM, VDP2 struct, VDP1 regs.
+ *   server -> client : a 36-byte little-endian header, then the payloads in
+ *                      order: VDP1 VRAM, VDP2 VRAM, CRAM, VDP2 struct, VDP1 regs,
+ *                      low work RAM, high work RAM.
  *
  * Byte conventions match what the core (and the savestate driver) expect:
  *   - VDP1/VDP2 VRAM : Saturn-native big-endian (Yabause stores it that way).
@@ -15,6 +16,9 @@
  *                      rebuilds the hardware-offset image via BuildVdp2RegImage).
  *   - VDP1 regs      : a ready hardware-offset, big-endian VDP1 register image
  *                      (0x18 bytes) the server assembles from its Vdp1 struct.
+ *   - Work RAM       : raw bytes (1 MiB low @ 0x00200000, 1 MiB high @ 0x06000000).
+ *
+ * Any section length may be 0 (that data unavailable this build/version).
  */
 #ifndef SATURNEXPLORER_SE_LIVE_PROTOCOL_H
 #define SATURNEXPLORER_SE_LIVE_PROTOCOL_H
@@ -23,10 +27,10 @@
 #define SE_LIVE_MAGIC1 'E'
 #define SE_LIVE_MAGIC2 'X'
 #define SE_LIVE_MAGIC3 'P'
-#define SE_LIVE_VERSION      1u
+#define SE_LIVE_VERSION      2u
 #define SE_LIVE_REQUEST      "GET\n"
 #define SE_LIVE_REQUEST_LEN  4
-#define SE_LIVE_HEADER_LEN   28   /* magic(4) + version(4) + 5 section lengths(4 each) */
+#define SE_LIVE_HEADER_LEN   36   /* magic(4) + version(4) + 7 section lengths(4 each) */
 
 /* Canonical section sizes (bytes). The header still carries the actual lengths,
  * so a client validates rather than assumes; these are the expected values. */
@@ -35,6 +39,8 @@
 #define SE_LIVE_CRAM_LEN        0x1000u
 #define SE_LIVE_VDP2_STRUCT_LEN 288u
 #define SE_LIVE_VDP1_REGS_LEN   0x18u
+#define SE_LIVE_WRAM_LOW_LEN    0x100000u
+#define SE_LIVE_WRAM_HIGH_LEN   0x100000u
 
 /* Default endpoints. */
 #define SE_LIVE_DEFAULT_SOCK_PATH "/tmp/saturn_explorer.sock"

--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
@@ -35,6 +35,8 @@ struct LiveSnapshot
     std::vector<uint8_t> cram;
     std::vector<uint8_t> vdp2Regs;   // hw-offset BE image
     std::vector<uint8_t> vdp1Regs;   // hw-offset BE image
+    std::vector<uint8_t> wramLow;    // 0x00200000, 1 MiB
+    std::vector<uint8_t> wramHigh;   // 0x06000000, 1 MiB
     bool                 valid = false;
 };
 
@@ -164,8 +166,11 @@ bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
     const uint32_t cr = Rd32LE(hdr + 16);
     const uint32_t vs = Rd32LE(hdr + 20);
     const uint32_t vr = Rd32LE(hdr + 24);
+    const uint32_t wl = Rd32LE(hdr + 28);
+    const uint32_t wh = Rd32LE(hdr + 32);
     // Sanity clamps so a malformed header can't drive a huge allocation.
-    if (v1 > 0x100000u || v2 > 0x100000u || cr > 0x4000u || vs > 4096u || vr > 256u)
+    if (v1 > 0x100000u || v2 > 0x100000u || cr > 0x4000u || vs > 4096u ||
+        vr > 256u || wl > 0x100000u || wh > 0x100000u)
     {
         return false;
     }
@@ -175,11 +180,15 @@ bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
     snap.cram.resize(cr);
     std::vector<uint8_t> vdp2Struct(vs);
     snap.vdp1Regs.resize(vr);
+    snap.wramLow.resize(wl);
+    snap.wramHigh.resize(wh);
     if (!ConnReadFull(c, snap.vdp1Vram.data(), v1) ||
         !ConnReadFull(c, snap.vdp2Vram.data(), v2) ||
         !ConnReadFull(c, snap.cram.data(), cr) ||
         !ConnReadFull(c, vdp2Struct.data(), vs) ||
-        !ConnReadFull(c, snap.vdp1Regs.data(), vr))
+        !ConnReadFull(c, snap.vdp1Regs.data(), vr) ||
+        !ConnReadFull(c, snap.wramLow.data(), wl) ||
+        !ConnReadFull(c, snap.wramHigh.data(), wh))
     {
         return false;
     }
@@ -252,7 +261,19 @@ size_t CbCram(void* u, uint32_t off, void* dst, size_t size)
     LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
     return CopyRegion(st->front.cram, off, dst, size);
 }
-size_t CbMainRam(void* u, uint32_t, void*, size_t) { (void)u; return 0; }
+size_t CbMainRam(void* u, uint32_t address, void* dst, size_t size)
+{
+    LiveState* st = St(u); std::lock_guard<std::mutex> lk(st->mtx);
+    if (address >= 0x06000000u)
+    {
+        return CopyRegion(st->front.wramHigh, address - 0x06000000u, dst, size);
+    }
+    if (address >= 0x00200000u)
+    {
+        return CopyRegion(st->front.wramLow, address - 0x00200000u, dst, size);
+    }
+    return 0;
+}
 
 uint16_t CbVdp1Reg(void* u, uint32_t reg)
 {
@@ -313,7 +334,7 @@ extern "C" se_result se_live_open(const char* endpoint, se_data_source* out)
 
     out->abi_version = SE_ABI_VERSION;
     out->capabilities = SE_CAP_VDP1_VRAM | SE_CAP_VDP2_VRAM | SE_CAP_CRAM |
-                        SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS;
+                        SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS | SE_CAP_MAIN_RAM;
     out->user = st;
     out->read_vdp1_vram = CbVdp1Vram;
     out->read_vdp2_vram = CbVdp2Vram;

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -378,6 +378,7 @@ void App::BuildUI(IPlatform& platform)
     DrawVdp1Table();
     DrawVdp2Table();
     DrawColorRam();
+    DrawWorkRam();
     DrawPlaceholder("Palette RAM", "VDP1 CLUT-area view — planned (see Color RAM for CRAM).");
     DrawRegisters();
     DrawCommandList();
@@ -440,6 +441,7 @@ void App::BuildDefaultLayout(unsigned int dockspaceId)
     ImGui::DockBuilderDockWindow("VDP1 Table", centerTop);
     ImGui::DockBuilderDockWindow("VDP2 Table", centerTop);
     ImGui::DockBuilderDockWindow("Color RAM", centerTop);
+    ImGui::DockBuilderDockWindow("Work RAM", centerTop);
     ImGui::DockBuilderDockWindow("Palette RAM", centerTop);
     ImGui::DockBuilderDockWindow("Registers", centerTop);
     ImGui::DockBuilderDockWindow("3D View", centerTop);
@@ -1577,6 +1579,74 @@ void App::DrawVdp1Table()
                 }
                 ImGui::EndTable();
             }
+        }
+    }
+    ImGui::End();
+}
+
+void App::DrawWorkRam()
+{
+    if (ImGui::Begin("Work RAM"))
+    {
+        if (!mbHasData)
+        {
+            ImGui::TextDisabled("No data loaded.");
+        }
+        else if (ImGui::BeginTabBar("wramtabs"))
+        {
+            struct Bank { const char* name; se_vram_kind kind; uint32_t base; };
+            const Bank banks[2] = {
+                {"Low (0x00200000)",  SE_VRAM_KIND_WRAM_LOW,  0x00200000u},
+                {"High (0x06000000)", SE_VRAM_KIND_WRAM_HIGH, 0x06000000u},
+            };
+            for (const Bank& b : banks)
+            {
+                if (!ImGui::BeginTabItem(b.name))
+                {
+                    continue;
+                }
+                uint8_t probe[16];
+                if (se_read_vram(mContext, b.kind, 0, probe, sizeof(probe)) == 0)
+                {
+                    ImGui::TextDisabled("Not available for this source "
+                                        "(connect to a live emulator, or load a full dump).");
+                }
+                else
+                {
+                    ImGui::BeginChild("wramhex");   // always paired with EndChild
+                    const int cols = 16;
+                    const int rows = 0x100000 / cols;   // 1 MiB / 16
+                    ImGuiListClipper clip;
+                    clip.Begin(rows);
+                    while (clip.Step())
+                    {
+                        for (int r = clip.DisplayStart; r < clip.DisplayEnd; ++r)
+                        {
+                            uint8_t row[16] = {};
+                            se_read_vram(mContext, b.kind,
+                                         static_cast<uint32_t>(r * cols), row, cols);
+                            char line[128];
+                            int p = std::snprintf(line, sizeof(line), "%08X  ",
+                                                  b.base + static_cast<uint32_t>(r * cols));
+                            for (int i = 0; i < cols; ++i)
+                            {
+                                p += std::snprintf(line + p, sizeof(line) - p, "%02X ", row[i]);
+                            }
+                            if (p < static_cast<int>(sizeof(line)) - 1) line[p++] = ' ';
+                            for (int i = 0; i < cols && p < static_cast<int>(sizeof(line)) - 1; ++i)
+                            {
+                                const uint8_t c = row[i];
+                                line[p++] = (c >= 32 && c < 127) ? static_cast<char>(c) : '.';
+                            }
+                            line[p] = '\0';
+                            ImGui::TextUnformatted(line);
+                        }
+                    }
+                    ImGui::EndChild();
+                }
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
         }
     }
     ImGui::End();

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -58,6 +58,7 @@ private:
     void DrawReferenceList(const char* id, const std::vector<se_reference>& refs);
     void DrawRegisters();
     void DrawColorRam();
+    void DrawWorkRam();
     void DrawVdp1Table();
     void DrawVdp2Table();
     void DrawPlaceholder(const char* title, const char* note);

--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -40,13 +40,15 @@ frame, after the frame is drawn):
 ```c
 #include "se_export.h"
     /* ... existing VBlankOUT body ... */
-    SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs);
+    SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,
+                     Vdp1Regs, LowWram, HighWram);
 ```
 
-`Vdp1Ram`, `Vdp2Ram`, `Vdp2ColorRam` are Yabause's VDP RAM globals; `Vdp2Regs` is
-its `Vdp2*` register struct. (These names are stable across the Yabause family. If
-your fork renamed them, pass the equivalents — the module just needs the four
-pointers.) That's the whole patch.
+`Vdp1Ram`/`Vdp2Ram`/`Vdp2ColorRam` are Yabause's VDP RAM globals; `Vdp2Regs` and
+`Vdp1Regs` are its register structs; `LowWram`/`HighWram` are the 1 MiB work-RAM
+globals (declared in `memory.h`). These names are stable across the Yabause family;
+if your fork renamed them, pass the equivalents. Any argument may be NULL to omit
+that section. That's the whole patch.
 
 ## 3. Build & run
 1. Build Yabause as usual (the port you use for Sakura Wars, etc.).
@@ -57,17 +59,14 @@ pointers.) That's the whole patch.
 
 ## What flows over the wire
 Per request, the server sends: VDP1 VRAM (512 KiB), VDP2 VRAM (512 KiB), CRAM
-(4 KiB), and the 288-byte VDP2 register struct — the exact bytes Saturn Explorer's
-savestate loader already understands (VRAM big-endian, CRAM host-endian, VDP2 the
-raw struct). Wire format: `Drivers/Common/src/SeLiveProtocol.h`.
+(4 KiB), the 288-byte VDP2 register struct, the VDP1 register image, and low + high
+work RAM (1 MiB each) — the exact bytes Saturn Explorer's savestate loader already
+understands (VRAM big-endian, CRAM host-endian, VDP2 the raw struct). Wire format:
+`Drivers/Common/src/SeLiveProtocol.h`.
 
-## Notes / limits (v1)
+## Notes / limits
 - **Transport:** Unix domain socket `/tmp/saturn_explorer.sock` (Linux/macOS) or
   named pipe `\\.\pipe\SaturnExplorer` (Windows). Local only.
-- **VDP1 registers** aren't streamed yet (most VDP1 draw state lives in the command
-  table, which *is* streamed via VDP1 VRAM). The wire format reserves a slot; to add
-  them, assemble a 0x18-byte big-endian image from Yabause's `Vdp1Regs` fields and
-  send it in place of the current zero-length section.
-- **Work RAM / disc / frame-step** aren't exported yet; easy follow-ons.
+- **Disc / frame-step** aren't exported yet; easy follow-ons.
 - The snapshot is taken at vblank under a lock and double-buffered, so the client
   always reads a whole, consistent frame.

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -21,15 +21,46 @@
 #define SE_V2 SE_LIVE_VDP2_VRAM_LEN
 #define SE_CR SE_LIVE_CRAM_LEN
 #define SE_VS SE_LIVE_VDP2_STRUCT_LEN
+#define SE_VR SE_LIVE_VDP1_REGS_LEN
+#define SE_WL SE_LIVE_WRAM_LOW_LEN
+#define SE_WH SE_LIVE_WRAM_HIGH_LEN
 
 typedef struct
 {
-    unsigned char v1[SE_V1];
-    unsigned char v2[SE_V2];
-    unsigned char cr[SE_CR];
-    unsigned char vs[SE_VS];
+    unsigned char v1[SE_V1];   /* VDP1 VRAM */
+    unsigned char v2[SE_V2];   /* VDP2 VRAM */
+    unsigned char cr[SE_CR];   /* CRAM */
+    unsigned char vs[SE_VS];   /* raw Vdp2 register struct */
+    unsigned char vr[SE_VR];   /* hardware-offset BE VDP1 register image */
+    unsigned char wl[SE_WL];   /* low work RAM */
+    unsigned char wh[SE_WH];   /* high work RAM */
     int valid;
 } SeFrame;
+
+/* Build the hardware-offset, big-endian VDP1 register image from Yabause's Vdp1
+ * struct (first 11 u16 fields: TVMR,FBCR,PTMR,EWDR,EWLR,EWRR,ENDR,EDSR,LOPR,COPR,
+ * MODR, host byte order). Hardware has a 1-word gap at 0x0E, so EDSR..MODR shift
+ * up by 2 relative to their struct index. */
+static void SeBuildVdp1Image(const unsigned char* dst_img, const void* vdp1struct)
+{
+    unsigned char* out = (unsigned char*)dst_img;
+    const unsigned short* r = (const unsigned short*)vdp1struct;
+    int i;
+    memset(out, 0, SE_VR);
+    if (!r)
+    {
+        return;
+    }
+    for (i = 0; i < 11; ++i)
+    {
+        unsigned hw = (i <= 6) ? (unsigned)(i * 2) : (unsigned)(i * 2 + 2);
+        if (hw + 1 < SE_VR)
+        {
+            out[hw]     = (unsigned char)((r[i] >> 8) & 0xFF);
+            out[hw + 1] = (unsigned char)(r[i] & 0xFF);
+        }
+    }
+}
 
 static SeFrame* sFront;
 static SeFrame* sBack;
@@ -56,7 +87,9 @@ static void SeWr32(unsigned char* p, unsigned int v)
     p[3] = (unsigned char)((v >> 24) & 0xFF);
 }
 
-void SeExportSnapshot(const void* vdp1, const void* vdp2, const void* cram, const void* vdp2struct)
+void SeExportSnapshot(const void* vdp1, const void* vdp2, const void* cram,
+                      const void* vdp2struct, const void* vdp1struct,
+                      const void* wramLow, const void* wramHigh)
 {
     if (!sBack)
     {
@@ -67,6 +100,9 @@ void SeExportSnapshot(const void* vdp1, const void* vdp2, const void* cram, cons
     if (vdp2) memcpy(sBack->v2, vdp2, SE_V2); else memset(sBack->v2, 0, SE_V2);
     if (cram) memcpy(sBack->cr, cram, SE_CR); else memset(sBack->cr, 0, SE_CR);
     if (vdp2struct) memcpy(sBack->vs, vdp2struct, SE_VS); else memset(sBack->vs, 0, SE_VS);
+    SeBuildVdp1Image(sBack->vr, vdp1struct);
+    if (wramLow)  memcpy(sBack->wl, wramLow,  SE_WL); else memset(sBack->wl, 0, SE_WL);
+    if (wramHigh) memcpy(sBack->wh, wramHigh, SE_WH); else memset(sBack->wh, 0, SE_WH);
     sBack->valid = 1;
     {
         SeFrame* tmp = sFront; sFront = sBack; sBack = tmp;   /* swap */
@@ -121,13 +157,17 @@ static void SeServeClient(int cl, SeFrame* snap)
         hdr[0] = SE_LIVE_MAGIC0; hdr[1] = SE_LIVE_MAGIC1;
         hdr[2] = SE_LIVE_MAGIC2; hdr[3] = SE_LIVE_MAGIC3;
         SeWr32(hdr + 4, SE_LIVE_VERSION);
-        SeWr32(hdr + 8, SE_V1); SeWr32(hdr + 12, SE_V2); SeWr32(hdr + 16, SE_CR);
-        SeWr32(hdr + 20, SE_VS); SeWr32(hdr + 24, 0);   /* no VDP1 regs in v1 */
+        SeWr32(hdr + 8, SE_V1);  SeWr32(hdr + 12, SE_V2); SeWr32(hdr + 16, SE_CR);
+        SeWr32(hdr + 20, SE_VS); SeWr32(hdr + 24, SE_VR); SeWr32(hdr + 28, SE_WL);
+        SeWr32(hdr + 32, SE_WH);
         if (SeSend(cl, hdr, sizeof(hdr)) != 0) return;
         if (SeSend(cl, snap->v1, SE_V1) != 0) return;
         if (SeSend(cl, snap->v2, SE_V2) != 0) return;
         if (SeSend(cl, snap->cr, SE_CR) != 0) return;
         if (SeSend(cl, snap->vs, SE_VS) != 0) return;
+        if (SeSend(cl, snap->vr, SE_VR) != 0) return;
+        if (SeSend(cl, snap->wl, SE_WL) != 0) return;
+        if (SeSend(cl, snap->wh, SE_WH) != 0) return;
     }
 }
 

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -24,13 +24,17 @@ extern "C" {
  * success, non-zero on failure (Yabause keeps running either way). */
 int SeExportInit(void);
 
-/* Copy the current VDP memory into the export double-buffer. Call once per frame,
- * e.g. at the end of Vdp2VBlankOUT(), passing Yabause's globals:
- *   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs);
- * Sizes are fixed by the hardware (512 KiB / 512 KiB / 4 KiB / 288 bytes). Any
- * argument may be NULL (that section is sent as zeros). */
+/* Copy the current Saturn memory into the export double-buffer. Call once per
+ * frame, e.g. at the end of Vdp2VBlankOUT(), passing Yabause's globals:
+ *   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,
+ *                    Vdp1Regs, LowWram, HighWram);
+ * Sizes are fixed by the hardware. 'vdp1_regs_struct' is Yabause's `Vdp1` struct
+ * (its first 11 u16 fields TVMR..MODR); this module builds the hardware-offset
+ * register image from it. Any argument may be NULL (that section is zeros). */
 void SeExportSnapshot(const void* vdp1_vram_512k, const void* vdp2_vram_512k,
-                      const void* cram_4k, const void* vdp2_regs_struct_288);
+                      const void* cram_4k, const void* vdp2_regs_struct_288,
+                      const void* vdp1_regs_struct, const void* wram_low_1m,
+                      const void* wram_high_1m);
 
 /* Stop the server thread and free resources. */
 void SeExportDeinit(void);

--- a/SaturnExplorer/include/saturnexplorer/SeTypes.h
+++ b/SaturnExplorer/include/saturnexplorer/SeTypes.h
@@ -102,7 +102,9 @@ typedef enum se_cram_mode {
 typedef enum se_vram_kind {
     SE_VRAM_KIND_VDP1_VRAM = 0,
     SE_VRAM_KIND_VDP2_VRAM = 1,
-    SE_VRAM_KIND_CRAM      = 2
+    SE_VRAM_KIND_CRAM      = 2,
+    SE_VRAM_KIND_WRAM_LOW  = 3,  /* work RAM low  (0x00200000, 1 MiB) */
+    SE_VRAM_KIND_WRAM_HIGH = 4   /* work RAM high (0x06000000, 1 MiB) */
 } se_vram_kind;
 
 /* ------------------------------------------------------------------ *


### PR DESCRIPTION
Extends the live driver (M7) to stream the **VDP1 register file** and **both work-RAM banks** from a running, patched Yabause, and adds a **Work RAM viewer** panel. Builds directly on the merged live-driver foundation (#12).

## What's new
- **Wire protocol v2** (`SeLiveProtocol.h`) — header grows from 4 to 7 section lengths. New sections: VDP1 registers (0x18-byte hardware-offset image), work RAM low (1 MiB @ `0x00200000`), work RAM high (1 MiB @ `0x06000000`).
- **Yabause export** (`Integration/Yabause/se_export.c`) — `SeBuildVdp1Image()` serialises the `Vdp1` struct's first 11 registers into a hardware-offset big-endian image (handles the gap at offset `0x0E`); `SeExportSnapshot()` now also takes `vdp1_regs`, `wram_low`, `wram_high`; the serve loop writes the new sections. README patch snippet updated to the new signature.
- **LiveDriver** (`Drivers/Live/`) — parses the 7 sections, clamps work-RAM lengths, implements the main-RAM read callback (`>=0x06000000` → high bank, `>=0x00200000` → low bank), and advertises `SE_CAP_MAIN_RAM`.
- **Core** — `HardwareSnapshot` captures both work-RAM banks when `SE_CAP_MAIN_RAM` is present; `Context::ReadVram` routes the two new kinds. `SeTypes.h` gains `SE_VRAM_KIND_WRAM_LOW` / `SE_VRAM_KIND_WRAM_HIGH`.
- **Frontend** — `DrawWorkRam()` hex + ASCII viewer with **Low / High** tabs, docked beside Color RAM.

## Verification
- End-to-end over the ABI against a mock Yabause server: every VDP1 register reads back correct (TVMR, FBCR, EWDR, EWRR, EDSR, LOPR, MODR, …) and both work-RAM banks render live in the new panel (`caps=0x3f`, hex dump matches the served pattern and wraps correctly).
- Native desktop (SDL2) and web (Emscripten/WASM) builds compile clean; the golden Battle3 render is unchanged. The live driver remains native-only (excluded from the web build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_