### PR TITLE
Live: pause / single-step frame control

### DIFF
--- a/SaturnExplorer/Core/src/HostAbi.cpp
+++ b/SaturnExplorer/Core/src/HostAbi.cpp
@@ -290,4 +290,78 @@ se_result se_get_system_status(se_context* ctx, se_system_status* out)
     return SE_ERR_NO_CAPABILITY;
 }
 
+/* --- Frame control --- */
+int se_supports_frame_control(se_context* ctx)
+{
+    if (!ctx)
+    {
+        return 0;
+    }
+    const se_data_source& ds = Impl(ctx)->DataSource();
+    return (ds.capabilities & SE_CAP_FRAME_STEP) && ds.frame_pause && ds.frame_step
+               ? 1
+               : 0;
+}
+
+se_result se_frame_pause(se_context* ctx)
+{
+    if (!ctx)
+    {
+        return SE_ERR_INVALID_ARG;
+    }
+    const se_data_source& ds = Impl(ctx)->DataSource();
+    if (!(ds.capabilities & SE_CAP_FRAME_STEP) || !ds.frame_pause)
+    {
+        return SE_ERR_NO_CAPABILITY;
+    }
+    return ds.frame_pause(ds.user) == 0 ? SE_OK : SE_ERR_IO;
+}
+
+se_result se_frame_resume(se_context* ctx)
+{
+    if (!ctx)
+    {
+        return SE_ERR_INVALID_ARG;
+    }
+    const se_data_source& ds = Impl(ctx)->DataSource();
+    if (!(ds.capabilities & SE_CAP_FRAME_STEP) || !ds.frame_step)
+    {
+        return SE_ERR_NO_CAPABILITY;
+    }
+    /* By the seam's contract, stepping <= 0 frames means "run free" (resume). */
+    return ds.frame_step(ds.user, 0) == 0 ? SE_OK : SE_ERR_IO;
+}
+
+se_result se_frame_step(se_context* ctx, int32_t frames)
+{
+    if (!ctx)
+    {
+        return SE_ERR_INVALID_ARG;
+    }
+    const se_data_source& ds = Impl(ctx)->DataSource();
+    if (!(ds.capabilities & SE_CAP_FRAME_STEP) || !ds.frame_step)
+    {
+        return SE_ERR_NO_CAPABILITY;
+    }
+    if (frames < 1)
+    {
+        frames = 1;
+    }
+    return ds.frame_step(ds.user, frames) == 0 ? SE_OK : SE_ERR_IO;
+}
+
+uint64_t se_frame_number(se_context* ctx)
+{
+    if (!ctx)
+    {
+        return 0;
+    }
+    const se_data_source& ds = Impl(ctx)->DataSource();
+    if ((ds.capabilities & SE_CAP_FRAME_STEP) && ds.frame_number)
+    {
+        return ds.frame_number(ds.user);
+    }
+    return 0;
+}
+
 }  // extern "C"

--- a/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
+++ b/SaturnExplorer/Drivers/Common/src/SeLiveProtocol.h
@@ -4,10 +4,18 @@
  * Transport: a local stream socket (Unix domain socket on POSIX, named pipe on
  * Windows). Request/response, one snapshot per request:
  *
- *   client -> server : the 4 bytes "GET\n"
- *   server -> client : a 36-byte little-endian header, then the payloads in
+ *   client -> server : an 8-byte command frame: a 4-byte verb + a 4-byte
+ *                      little-endian argument. Verbs:
+ *                        "GET\n" (arg 0)  request a snapshot
+ *                        "PAU\n" (arg 0)  pause after the current frame
+ *                        "RUN\n" (arg 0)  resume free-running
+ *                        "STP\n" (arg n)  run n frames, then pause
+ *                      Every verb replies with a full snapshot reflecting the
+ *                      new run state, so the client stays in sync with one code
+ *                      path.
+ *   server -> client : a 40-byte little-endian header, then the payloads in
  *                      order: VDP1 VRAM, VDP2 VRAM, CRAM, VDP2 struct, VDP1 regs,
- *                      low work RAM, high work RAM.
+ *                      low work RAM, high work RAM, control block.
  *
  * Byte conventions match what the core (and the savestate driver) expect:
  *   - VDP1/VDP2 VRAM : Saturn-native big-endian (Yabause stores it that way).
@@ -17,6 +25,9 @@
  *   - VDP1 regs      : a ready hardware-offset, big-endian VDP1 register image
  *                      (0x18 bytes) the server assembles from its Vdp1 struct.
  *   - Work RAM       : raw bytes (1 MiB low @ 0x00200000, 1 MiB high @ 0x06000000).
+ *   - Control block  : paused flag (u32 LE, 1 = paused) + frame counter (u64 LE),
+ *                      so the client can label the pause button and show the
+ *                      current frame without an extra round-trip.
  *
  * Any section length may be 0 (that data unavailable this build/version).
  */
@@ -27,10 +38,16 @@
 #define SE_LIVE_MAGIC1 'E'
 #define SE_LIVE_MAGIC2 'X'
 #define SE_LIVE_MAGIC3 'P'
-#define SE_LIVE_VERSION      2u
-#define SE_LIVE_REQUEST      "GET\n"
-#define SE_LIVE_REQUEST_LEN  4
-#define SE_LIVE_HEADER_LEN   36   /* magic(4) + version(4) + 7 section lengths(4 each) */
+#define SE_LIVE_VERSION      3u
+/* Command verbs are exactly 4 bytes; a request is a verb + 4-byte LE argument. */
+#define SE_LIVE_REQUEST      "GET\n"   /* back-compat alias for the snapshot verb */
+#define SE_LIVE_VERB_GET     "GET\n"
+#define SE_LIVE_VERB_PAUSE   "PAU\n"
+#define SE_LIVE_VERB_RESUME  "RUN\n"
+#define SE_LIVE_VERB_STEP    "STP\n"
+#define SE_LIVE_VERB_LEN     4
+#define SE_LIVE_REQUEST_LEN  8    /* verb(4) + arg(4, little-endian) */
+#define SE_LIVE_HEADER_LEN   40   /* magic(4) + version(4) + 8 section lengths(4 each) */
 
 /* Canonical section sizes (bytes). The header still carries the actual lengths,
  * so a client validates rather than assumes; these are the expected values. */
@@ -41,6 +58,7 @@
 #define SE_LIVE_VDP1_REGS_LEN   0x18u
 #define SE_LIVE_WRAM_LOW_LEN    0x100000u
 #define SE_LIVE_WRAM_HIGH_LEN   0x100000u
+#define SE_LIVE_CONTROL_LEN     12u       /* paused(u32 LE) + frame(u64 LE) */
 
 /* Default endpoints. */
 #define SE_LIVE_DEFAULT_SOCK_PATH "/tmp/saturn_explorer.sock"

--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
@@ -40,6 +40,11 @@ struct LiveSnapshot
     bool                 valid = false;
 };
 
+// Pending control command the UI thread hands to the poll thread (which owns the
+// single server connection). Best-effort: the poll thread drains it within one
+// cycle (~8 ms). Steps accumulate so rapid presses aren't lost.
+enum class Ctl { None, Pause, Resume, Step };
+
 struct LiveState
 {
     std::string       endpoint;
@@ -47,6 +52,14 @@ struct LiveState
     std::atomic<bool> running{false};
     std::mutex        mtx;           // guards 'front'
     LiveSnapshot      front;
+
+    // Frame control (SE_CAP_FRAME_STEP). Updated from each snapshot's control
+    // block; the callbacks post a command for the poll thread to send.
+    std::atomic<uint64_t> frameNumber{0};
+    std::atomic<bool>     paused{false};
+    std::mutex            ctlMtx;    // guards pending / stepFrames
+    Ctl                   pending = Ctl::None;
+    int32_t               stepFrames = 0;
 };
 
 /* ---- Local-socket transport (POSIX Unix socket / Windows named pipe). ---- */
@@ -142,11 +155,26 @@ uint32_t Rd32LE(const uint8_t* p)
            (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
 }
 
-// Read one snapshot from a connected socket into 'snap' (converted to core-ready
-// form). Returns false on any protocol/socket error.
-bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
+// Send one command frame (verb + little-endian arg) to the server.
+bool SendCommand(Conn& c, const char* verb, int32_t arg)
 {
-    if (!ConnWrite(c, SE_LIVE_REQUEST, SE_LIVE_REQUEST_LEN))
+    uint8_t req[SE_LIVE_REQUEST_LEN];
+    std::memcpy(req, verb, SE_LIVE_VERB_LEN);
+    const uint32_t a = static_cast<uint32_t>(arg);
+    req[4] = static_cast<uint8_t>(a & 0xFF);
+    req[5] = static_cast<uint8_t>((a >> 8) & 0xFF);
+    req[6] = static_cast<uint8_t>((a >> 16) & 0xFF);
+    req[7] = static_cast<uint8_t>((a >> 24) & 0xFF);
+    return ConnWrite(c, req, sizeof(req));
+}
+
+// Issue 'verb' (arg) and read the snapshot the server replies with into 'snap'
+// (converted to core-ready form). Also returns the run state via outPaused /
+// outFrame. Returns false on any protocol/socket error.
+bool ReadSnapshot(Conn& c, const char* verb, int32_t arg, LiveSnapshot& snap,
+                  bool& outPaused, uint64_t& outFrame)
+{
+    if (!SendCommand(c, verb, arg))
     {
         return false;
     }
@@ -168,9 +196,10 @@ bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
     const uint32_t vr = Rd32LE(hdr + 24);
     const uint32_t wl = Rd32LE(hdr + 28);
     const uint32_t wh = Rd32LE(hdr + 32);
+    const uint32_t ct = Rd32LE(hdr + 36);
     // Sanity clamps so a malformed header can't drive a huge allocation.
     if (v1 > 0x100000u || v2 > 0x100000u || cr > 0x4000u || vs > 4096u ||
-        vr > 256u || wl > 0x100000u || wh > 0x100000u)
+        vr > 256u || wl > 0x100000u || wh > 0x100000u || ct > 64u)
     {
         return false;
     }
@@ -182,16 +211,24 @@ bool ReadSnapshot(Conn& c, LiveSnapshot& snap)
     snap.vdp1Regs.resize(vr);
     snap.wramLow.resize(wl);
     snap.wramHigh.resize(wh);
+    std::vector<uint8_t> ctl(ct);
     if (!ConnReadFull(c, snap.vdp1Vram.data(), v1) ||
         !ConnReadFull(c, snap.vdp2Vram.data(), v2) ||
         !ConnReadFull(c, snap.cram.data(), cr) ||
         !ConnReadFull(c, vdp2Struct.data(), vs) ||
         !ConnReadFull(c, snap.vdp1Regs.data(), vr) ||
         !ConnReadFull(c, snap.wramLow.data(), wl) ||
-        !ConnReadFull(c, snap.wramHigh.data(), wh))
+        !ConnReadFull(c, snap.wramHigh.data(), wh) ||
+        !ConnReadFull(c, ctl.data(), ct))
     {
         return false;
     }
+
+    // Control block: paused (u32 LE) + frame (u64 LE). Absent on older servers.
+    outPaused = ct >= 4 && Rd32LE(ctl.data()) != 0;
+    outFrame = ct >= 12 ? (static_cast<uint64_t>(Rd32LE(ctl.data() + 4)) |
+                           (static_cast<uint64_t>(Rd32LE(ctl.data() + 8)) << 32))
+                        : 0;
 
     // VRAM is already big-endian; build the VDP2 register image and use RAMCTL's
     // CRAM mode to normalize CRAM — exactly like the savestate path.
@@ -215,8 +252,27 @@ void PollLoop(LiveState* st)
                 continue;
             }
         }
+
+        // Drain any control command posted by the UI thread; otherwise poll.
+        const char* verb = SE_LIVE_VERB_GET;
+        int32_t arg = 0;
+        {
+            std::lock_guard<std::mutex> lk(st->ctlMtx);
+            switch (st->pending)
+            {
+                case Ctl::Pause:  verb = SE_LIVE_VERB_PAUSE;  break;
+                case Ctl::Resume: verb = SE_LIVE_VERB_RESUME; break;
+                case Ctl::Step:   verb = SE_LIVE_VERB_STEP; arg = st->stepFrames; break;
+                default: break;
+            }
+            st->pending = Ctl::None;
+            st->stepFrames = 0;
+        }
+
         LiveSnapshot snap;
-        if (!ReadSnapshot(conn, snap))
+        bool paused = false;
+        uint64_t frame = 0;
+        if (!ReadSnapshot(conn, verb, arg, snap, paused, frame))
         {
             ConnClose(conn);   // will reconnect next iteration
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -226,6 +282,8 @@ void PollLoop(LiveState* st)
             std::lock_guard<std::mutex> lk(st->mtx);
             st->front = std::move(snap);
         }
+        st->paused.store(paused);
+        st->frameNumber.store(frame);
         std::this_thread::sleep_for(std::chrono::milliseconds(8));   // ~120 Hz cap
     }
     ConnClose(conn);
@@ -286,6 +344,39 @@ uint16_t CbVdp2Reg(void* u, uint32_t reg)
     return sedrv::ReadReg16(st->front.vdp2Regs, reg);
 }
 
+// ---- Frame control. The UI thread posts a command; the poll thread sends it
+//      over the shared connection on its next cycle (see PollLoop). ----
+void PostCmd(LiveState* st, Ctl cmd, int32_t frames)
+{
+    std::lock_guard<std::mutex> lk(st->ctlMtx);
+    if (cmd == Ctl::Step && st->pending == Ctl::Step)
+    {
+        st->stepFrames += frames;   // accumulate rapid presses
+    }
+    else
+    {
+        st->pending = cmd;
+        st->stepFrames = (cmd == Ctl::Step) ? frames : 0;
+    }
+}
+
+int CbFramePause(void* u)
+{
+    PostCmd(St(u), Ctl::Pause, 0);
+    return 0;
+}
+int CbFrameStep(void* u, int32_t frames)
+{
+    // By the seam's contract, frames <= 0 means "resume" (run free).
+    if (frames <= 0) { PostCmd(St(u), Ctl::Resume, 0); }
+    else             { PostCmd(St(u), Ctl::Step, frames); }
+    return 0;
+}
+uint64_t CbFrameNumber(void* u)
+{
+    return St(u)->frameNumber.load();
+}
+
 void CbClose(void* u)
 {
     LiveState* st = St(u);
@@ -334,7 +425,8 @@ extern "C" se_result se_live_open(const char* endpoint, se_data_source* out)
 
     out->abi_version = SE_ABI_VERSION;
     out->capabilities = SE_CAP_VDP1_VRAM | SE_CAP_VDP2_VRAM | SE_CAP_CRAM |
-                        SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS | SE_CAP_MAIN_RAM;
+                        SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS | SE_CAP_MAIN_RAM |
+                        SE_CAP_FRAME_STEP;
     out->user = st;
     out->read_vdp1_vram = CbVdp1Vram;
     out->read_vdp2_vram = CbVdp2Vram;
@@ -342,6 +434,9 @@ extern "C" se_result se_live_open(const char* endpoint, se_data_source* out)
     out->read_main_ram  = CbMainRam;
     out->read_vdp1_reg  = CbVdp1Reg;
     out->read_vdp2_reg  = CbVdp2Reg;
+    out->frame_pause    = CbFramePause;
+    out->frame_step     = CbFrameStep;
+    out->frame_number   = CbFrameNumber;
     out->close          = CbClose;
     return SE_OK;
 }

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -136,6 +136,7 @@ void App::CloseData()
     }
     mbHasData = false;
     mbLiveSource = false;
+    mbPaused = false;
     mSelectedCommand = -1;
     mSelection.clear();
     // The frame texture is freed lazily (on next size change) or with the
@@ -304,6 +305,7 @@ bool App::OpenLive(const char* endpoint)
     mDataSource = dataSource;
     mbHasData = true;
     mbLiveSource = true;   // re-snapshot every frame (see BuildUI)
+    mbPaused = false;      // a fresh connection is free-running
     return true;
 #else
     (void)endpoint;
@@ -505,12 +507,37 @@ void App::DrawToolbar(IPlatform& platform)
             ImGui::EndPopup();
         }
 
-        // Playback / stepping — stubbed until a live driver exists (M7).
+        // Playback / stepping — live when the source supports frame control
+        // (a running, patched Yabause); otherwise disabled.
+        const bool canStep = mbHasData && se_supports_frame_control(mContext);
+        ImGui::SameLine();
+        ImGui::BeginDisabled(!canStep);
+        if (mbPaused)
+        {
+            if (ImGui::Button("Resume", ImVec2(72.0f, 0.0f)))
+            {
+                se_frame_resume(mContext);
+                mbPaused = false;
+            }
+        }
+        else
+        {
+            if (ImGui::Button("Pause", ImVec2(72.0f, 0.0f)))
+            {
+                se_frame_pause(mContext);
+                mbPaused = true;
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Step Frame"))
+        {
+            se_frame_step(mContext, 1);
+            mbPaused = true;
+        }
+        ImGui::EndDisabled();
+        // Timeline scrubbing (rewind through captured frames) — future work.
         ImGui::SameLine();
         ImGui::BeginDisabled(true);
-        ImGui::Button("Pause"); ImGui::SameLine();
-        ImGui::Button("Step");  ImGui::SameLine();
-        ImGui::Button("Step Frame"); ImGui::SameLine();
         ImGui::Button("|<"); ImGui::SameLine(); ImGui::Button("<"); ImGui::SameLine();
         ImGui::Button(">"); ImGui::SameLine(); ImGui::Button(">|"); ImGui::SameLine();
         ImGui::EndDisabled();
@@ -563,10 +590,22 @@ void App::DrawStatusBar()
             {
                 ImGui::TextDisabled("No data loaded — Open ROM to begin.");
             }
-            // Live-only fields (frame / blanks / SH-2 PC / busy) arrive with the
-            // M7 live driver; shown here as placeholders to mirror the concept.
-            char right[128];
-            std::snprintf(right, sizeof(right), "Frame: -   |   Line: -   |   SH-2 PC: -   |   VDP1: -   VDP2: -");
+            // Frame counter + run state come from a live source (frame control);
+            // the remaining fields (scanline / SH-2 PC / busy) await a fuller
+            // live status feed and stay placeholders for now.
+            char right[160];
+            if (mbHasData && se_supports_frame_control(mContext))
+            {
+                std::snprintf(right, sizeof(right),
+                              "Frame: %llu (%s)   |   Line: -   |   SH-2 PC: -   |   VDP1: -   VDP2: -",
+                              static_cast<unsigned long long>(se_frame_number(mContext)),
+                              mbPaused ? "paused" : "running");
+            }
+            else
+            {
+                std::snprintf(right, sizeof(right),
+                              "Frame: -   |   Line: -   |   SH-2 PC: -   |   VDP1: -   VDP2: -");
+            }
             const float w = ImGui::CalcTextSize(right).x;
             ImGui::SameLine(ImGui::GetWindowWidth() - w - 12.0f);
             ImGui::TextDisabled("%s", right);

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -75,6 +75,7 @@ private:
 
     se_render_opts   mRenderOpts {};
     bool             mbLiveSource = false;    // data comes from a running emulator
+    bool             mbPaused = false;        // live emulator held paused (frame control)
     int              mSelectedCommand = -1;   // primary selection (detail panels)
     std::vector<int> mSelection;              // all selected command indices
     bool             mbLayoutBuilt = false;   // default dock layout applied once

--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -4,8 +4,13 @@ This lets Saturn Explorer read a **running** Yabause in realtime: Yabause runs a
 tiny local-socket server that streams its VDP1/VDP2 VRAM, CRAM, and VDP2 registers
 each frame; Saturn Explorer's **LiveDriver** connects and updates every panel live.
 
-It's a small, isolated patch to Yabause — one new module plus three one-line hook
-calls. It does not touch emulation logic, so it can't affect game compatibility.
+It also lets Saturn Explorer **pause and single-step** the running game (the
+toolbar's Pause / Step Frame buttons) so you can freeze a frame and inspect it.
+
+It's a small, isolated patch to Yabause — one new module plus a few one-line hook
+calls. The memory export doesn't touch emulation logic; the optional pause/step
+gate only decides *when* a frame runs, never *how*, so it can't affect game
+compatibility.
 
 ## 1. Copy three files into `yabause/src`
 - `se_export.h`
@@ -48,7 +53,30 @@ frame, after the frame is drawn):
 `Vdp1Regs` are its register structs; `LowWram`/`HighWram` are the 1 MiB work-RAM
 globals (declared in `memory.h`). These names are stable across the Yabause family;
 if your fork renamed them, pass the equivalents. Any argument may be NULL to omit
-that section. That's the whole patch.
+that section.
+
+## 2b. (Optional) Pause / single-step gate
+To enable the Pause and Step Frame buttons, gate each emulated frame on
+`SeExportGateFrame()` in Yabause's run loop. It returns 1 when the frame should
+run and 0 while the debugger is holding it paused; release exactly one frame per
+call when single-stepping. In `yabause/src/yabause.c`, in `YabauseEmulate()` (or
+your port's per-frame loop), wrap the frame:
+
+```c
+#include "se_export.h"
+
+int YabauseEmulate(void) {
+    /* ... at the top of the per-frame body, before running the frame: */
+    while (!SeExportGateFrame()) {
+        YabThreadUSleep(1000);      /* stay responsive to resume/step */
+        /* break here too on your loop's quit/reset condition */
+    }
+    /* ... existing frame emulation ... */
+}
+```
+
+Skip this block if you only want live viewing; without it the emulator always
+free-runs and the Pause / Step Frame buttons stay disabled. That's the whole patch.
 
 ## 3. Build & run
 1. Build Yabause as usual (the port you use for Sakura Wars, etc.).
@@ -58,15 +86,19 @@ that section. That's the whole patch.
    registers, textures — now tracks the running game.
 
 ## What flows over the wire
-Per request, the server sends: VDP1 VRAM (512 KiB), VDP2 VRAM (512 KiB), CRAM
-(4 KiB), the 288-byte VDP2 register struct, the VDP1 register image, and low + high
-work RAM (1 MiB each) — the exact bytes Saturn Explorer's savestate loader already
-understands (VRAM big-endian, CRAM host-endian, VDP2 the raw struct). Wire format:
-`Drivers/Common/src/SeLiveProtocol.h`.
+Each request is an 8-byte command (a verb — `GET`/`PAU`/`RUN`/`STP` — plus a
+little-endian argument). Every command replies with a full snapshot: VDP1 VRAM
+(512 KiB), VDP2 VRAM (512 KiB), CRAM (4 KiB), the 288-byte VDP2 register struct,
+the VDP1 register image, low + high work RAM (1 MiB each), and a small control
+block (paused flag + frame counter) — the exact bytes Saturn Explorer's savestate
+loader already understands (VRAM big-endian, CRAM host-endian, VDP2 the raw
+struct). The pause/step verbs just set the state `SeExportGateFrame()` reads.
+Wire format: `Drivers/Common/src/SeLiveProtocol.h`.
 
 ## Notes / limits
 - **Transport:** Unix domain socket `/tmp/saturn_explorer.sock` (Linux/macOS) or
   named pipe `\\.\pipe\SaturnExplorer` (Windows). Local only.
-- **Disc / frame-step** aren't exported yet; easy follow-ons.
+- **Pause / single-step** need the §2b gate; live viewing works without it.
+- **Disc access** isn't exported yet; an easy follow-on.
 - The snapshot is taken at vblank under a lock and double-buffered, so the client
   always reads a whole, consistent frame.

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -24,6 +24,7 @@
 #define SE_VR SE_LIVE_VDP1_REGS_LEN
 #define SE_WL SE_LIVE_WRAM_LOW_LEN
 #define SE_WH SE_LIVE_WRAM_HIGH_LEN
+#define SE_CT SE_LIVE_CONTROL_LEN
 
 typedef struct
 {
@@ -66,6 +67,33 @@ static SeFrame* sFront;
 static SeFrame* sBack;
 static volatile int sRunning;
 
+/* ---- Frame-control state (see SeExportGateFrame + the "PAU/RUN/STP" verbs). ----
+ * sPaused holds the emulator when set; sStepBudget lets a paused emulator run a
+ * bounded number of frames (single-step) before halting again. sFrameNo counts
+ * emulated frames (bumped by SeExportSnapshot, i.e. once per completed frame). */
+static volatile int sPaused;
+static volatile int sStepBudget;
+static volatile unsigned long long sFrameNo;
+
+/* Called by the emulator's run loop at the top of each frame: returns 1 if the
+ * frame should run, 0 if the debugger is holding it paused. When paused with a
+ * pending single-step budget, it releases exactly one frame per call. The host
+ * should sleep briefly and re-check when this returns 0 (so it stays responsive
+ * to a later resume/step). Safe to call even before SeExportInit (returns 1). */
+int SeExportGateFrame(void)
+{
+    if (!sPaused)
+    {
+        return 1;
+    }
+    if (sStepBudget > 0)
+    {
+        --sStepBudget;
+        return 1;
+    }
+    return 0;
+}
+
 #if defined(_WIN32)
 static HANDLE sThread;
 static CRITICAL_SECTION sLock;
@@ -107,6 +135,7 @@ void SeExportSnapshot(const void* vdp1, const void* vdp2, const void* cram,
     {
         SeFrame* tmp = sFront; sFront = sBack; sBack = tmp;   /* swap */
     }
+    ++sFrameNo;   /* one completed emulated frame */
     SE_UNLOCK();
 }
 
@@ -149,9 +178,37 @@ static void SeServeClient(int cl, SeFrame* snap)
 {
     while (sRunning)
     {
-        char req[SE_LIVE_REQUEST_LEN];
+        unsigned char req[SE_LIVE_REQUEST_LEN];
+        unsigned int arg;
         if (SeRecv(cl, req, SE_LIVE_REQUEST_LEN) != 0) return;
-        SE_LOCK(); memcpy(snap, sFront, sizeof(SeFrame)); SE_UNLOCK();
+        arg = (unsigned int)req[4] | ((unsigned int)req[5] << 8) |
+              ((unsigned int)req[6] << 16) | ((unsigned int)req[7] << 24);
+
+        /* Apply any control verb before snapshotting, so the reply's control
+         * block reflects the new state. Unknown verbs act like GET. */
+        if (memcmp(req, SE_LIVE_VERB_PAUSE, SE_LIVE_VERB_LEN) == 0)
+        {
+            SE_LOCK(); sPaused = 1; sStepBudget = 0; SE_UNLOCK();
+        }
+        else if (memcmp(req, SE_LIVE_VERB_RESUME, SE_LIVE_VERB_LEN) == 0)
+        {
+            SE_LOCK(); sPaused = 0; sStepBudget = 0; SE_UNLOCK();
+        }
+        else if (memcmp(req, SE_LIVE_VERB_STEP, SE_LIVE_VERB_LEN) == 0)
+        {
+            SE_LOCK();
+            sPaused = 1;
+            sStepBudget += (arg > 0) ? (int)arg : 1;
+            SE_UNLOCK();
+        }
+
+        unsigned char ctl[SE_CT];
+        SE_LOCK();
+        memcpy(snap, sFront, sizeof(SeFrame));
+        SeWr32(ctl, (unsigned int)(sPaused ? 1 : 0));
+        SeWr32(ctl + 4, (unsigned int)(sFrameNo & 0xFFFFFFFFu));
+        SeWr32(ctl + 8, (unsigned int)((sFrameNo >> 32) & 0xFFFFFFFFu));
+        SE_UNLOCK();
 
         unsigned char hdr[SE_LIVE_HEADER_LEN];
         hdr[0] = SE_LIVE_MAGIC0; hdr[1] = SE_LIVE_MAGIC1;
@@ -159,7 +216,7 @@ static void SeServeClient(int cl, SeFrame* snap)
         SeWr32(hdr + 4, SE_LIVE_VERSION);
         SeWr32(hdr + 8, SE_V1);  SeWr32(hdr + 12, SE_V2); SeWr32(hdr + 16, SE_CR);
         SeWr32(hdr + 20, SE_VS); SeWr32(hdr + 24, SE_VR); SeWr32(hdr + 28, SE_WL);
-        SeWr32(hdr + 32, SE_WH);
+        SeWr32(hdr + 32, SE_WH); SeWr32(hdr + 36, SE_CT);
         if (SeSend(cl, hdr, sizeof(hdr)) != 0) return;
         if (SeSend(cl, snap->v1, SE_V1) != 0) return;
         if (SeSend(cl, snap->v2, SE_V2) != 0) return;
@@ -168,6 +225,7 @@ static void SeServeClient(int cl, SeFrame* snap)
         if (SeSend(cl, snap->vr, SE_VR) != 0) return;
         if (SeSend(cl, snap->wl, SE_WL) != 0) return;
         if (SeSend(cl, snap->wh, SE_WH) != 0) return;
+        if (SeSend(cl, ctl, SE_CT) != 0) return;
     }
 }
 
@@ -226,6 +284,7 @@ int SeExportInit(void)
     sFront = (SeFrame*)calloc(1, sizeof(SeFrame));
     sBack  = (SeFrame*)calloc(1, sizeof(SeFrame));
     if (!sFront || !sBack) { SeExportDeinit(); return -1; }
+    sPaused = 0; sStepBudget = 0; sFrameNo = 0;
     sRunning = 1;
 #if defined(_WIN32)
     InitializeCriticalSection(&sLock);

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -1,9 +1,10 @@
 /* Saturn Explorer — Yabause memory-export server (drop-in module).
  *
- * Add this file + se_export.c + SeLiveProtocol.h to yabause/src, then wire three
+ * Add this file + se_export.c + SeLiveProtocol.h to yabause/src, then wire four
  * calls into Yabause (see README.md):
  *   - SeExportInit()      at the end of YabauseInit()
  *   - SeExportSnapshot(...) once per frame, from Vdp2VBlankOUT()
+ *   - SeExportGateFrame() in the run loop, to honor pause / single-step
  *   - SeExportDeinit()    in YabauseDeInit()
  *
  * It serves the current VDP1/VDP2 VRAM, CRAM, and VDP2 register struct to Saturn
@@ -35,6 +36,14 @@ void SeExportSnapshot(const void* vdp1_vram_512k, const void* vdp2_vram_512k,
                       const void* cram_4k, const void* vdp2_regs_struct_288,
                       const void* vdp1_regs_struct, const void* wram_low_1m,
                       const void* wram_high_1m);
+
+/* Frame gate for pause / single-step. Call once at the top of each emulated
+ * frame in Yabause's run loop; returns 1 if the frame should run, 0 if the
+ * debugger is holding it paused (sleep briefly and re-check, e.g.):
+ *   while (!SeExportGateFrame()) { YabThreadUSleep(1000); if (quitting) break; }
+ * When resumed or single-stepped from Saturn Explorer, it releases frames again.
+ * Returns 1 when the server isn't running, so an un-paused build is unaffected. */
+int SeExportGateFrame(void);
 
 /* Stop the server thread and free resources. */
 void SeExportDeinit(void);

--- a/SaturnExplorer/include/saturnexplorer/SeDataSource.h
+++ b/SaturnExplorer/include/saturnexplorer/SeDataSource.h
@@ -47,7 +47,10 @@ typedef struct se_data_source {
     int    (*disc_stat)(void* user, se_disc_info* out);
     size_t (*disc_read)(void* user, uint64_t byte_offset, void* dst, size_t size);
 
-    /* --- Optional: frame control (SE_CAP_FRAME_STEP). --- */
+    /* --- Optional: frame control (SE_CAP_FRAME_STEP). Return 0 on success.
+           frame_pause halts the emulator after the current frame. frame_step
+           advances 'frames' frames then re-pauses; 'frames' <= 0 means resume
+           (run free). frame_number is the current emulated-frame counter. --- */
     int      (*frame_pause) (void* user);
     int      (*frame_step)  (void* user, int32_t frames);
     uint64_t (*frame_number)(void* user);

--- a/SaturnExplorer/include/saturnexplorer/SeHost.h
+++ b/SaturnExplorer/include/saturnexplorer/SeHost.h
@@ -117,6 +117,20 @@ size_t      se_history_for(se_context* ctx, uint32_t address,
 /* --- System status (status bar) --- */
 se_result   se_get_system_status(se_context* ctx, se_system_status* out);
 
+/* --- Frame control (live sources only; requires SE_CAP_FRAME_STEP) ---
+   se_supports_frame_control returns 1 when the source can pause/step (so the
+   host can enable those toolbar buttons). pause halts the emulator after the
+   current frame; resume lets it free-run; step advances exactly 'frames' frames
+   and leaves it paused; frame_number is the current emulated-frame counter.
+   The control calls are asynchronous best-effort (they post to the live driver);
+   the effect is visible on the next snapshot. They return SE_ERR_NO_CAPABILITY
+   when the source doesn't support frame control. */
+int         se_supports_frame_control(se_context* ctx);
+se_result   se_frame_pause (se_context* ctx);
+se_result   se_frame_resume(se_context* ctx);
+se_result   se_frame_step  (se_context* ctx, int32_t frames);
+uint64_t    se_frame_number(se_context* ctx);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
Adds **pause / single-step** to the live path, so Saturn Explorer can freeze a running, patched Yabause and inspect a single frame. Builds on the live driver (#12) and the register/work-RAM streaming (#13).

## What's new
- **Wire protocol v3** (`SeLiveProtocol.h`) — the request becomes an 8-byte command frame (a 4-byte verb + LE argument): `GET` / `PAU` (pause) / `RUN` (resume) / `STP` (step N). Every reply now also carries a 12-byte **control block** (paused flag + frame counter), so the client tracks run state without extra round-trips. Header grows to 40 bytes.
- **Yabause export** (`se_export.c/.h`) — a small pause/step state machine plus `SeExportGateFrame()`, which the emulator's run loop calls at the top of each frame: it returns 0 while paused and releases exactly one frame per call when single-stepping. `SeExportSnapshot()` bumps the frame counter; the serve loop applies the control verbs and appends the control block. README **§2b** documents the (optional) one-block gate hook.
- **LiveDriver** — implements the `frame_pause` / `frame_step` / `frame_number` callbacks. Because the server keeps a single persistent connection, control commands are posted to the poll thread, which drains them each cycle, reads back paused + frame from the control block, and now advertises `SE_CAP_FRAME_STEP`.
- **Host ABI** (`SeHost.h` / `HostAbi.cpp`) — `se_supports_frame_control`, `se_frame_pause`, `se_frame_resume`, `se_frame_step`, `se_frame_number`. The seam contract is documented: `frame_step(n<=0)` means resume.
- **Frontend** — the toolbar's **Pause/Resume** and **Step Frame** buttons go live when the source supports frame control; the status bar shows the live **frame counter** and run state (`Frame: N (running/paused)`).

## Verification
- End-to-end over the ABI against a mock Yabause: the frame counter advances while running, **freezes** on pause, advances by **exactly one** on step (and stays paused), and resumes on resume — `PASS: live pause / single-step / resume over the ABI`.
- Visual: the Pause and Step Frame buttons are enabled against a live source and the status bar shows the advancing frame counter.
- `se_export.c` compiles as strict C11 (`-Wall -Wextra`); native desktop and web/WASM builds are clean; the golden Battle3 render is byte-identical (render path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_