### PR TITLE
VDP1: fix inverted MSB rule in LUT color decode

### DIFF
--- a/SaturnExplorer/Core/src/Vdp1Color.h
+++ b/SaturnExplorer/Core/src/Vdp1Color.h
@@ -81,11 +81,14 @@ inline Rgba DecodeTexel(const std::vector<uint8_t>& vram, const std::vector<uint
         const uint8_t p = (x & 1) ? (byte & 0x0F) : (byte >> 4);
         if (p == 0 && !spd) return { 0, 0, 0, 0 };
         const uint16_t entry = ReadBE16(vram, clutAddr + p * 2);
-        if (entry & 0x8000)   // color-bank code -> CRAM
+        // Saturn color word: MSB (bit 15) set = a direct RGB555 color; MSB clear
+        // = a CRAM color-bank index (VDP1 manual §5.x). Games often fill a CLUT
+        // with direct RGB colors (all MSB set), so this must not be inverted.
+        if (entry & 0x8000)
         {
-            return CramColor(cram, cramMode, entry & 0x7FF);
+            return Rgb555ToRgba(entry);   // direct RGB555
         }
-        return Rgb555ToRgba(entry);   // RGB555 literal
+        return CramColor(cram, cramMode, entry);   // CRAM color-bank index
     }
     case SE_COLOR_BANK_64:
     case SE_COLOR_BANK_128:


### PR DESCRIPTION
Fixes wrong colors on VDP1 **LUT** (color-lookup-table) sprites — the real cause of Panzer Dragoon Saga rendering as an orange wash.

## Problem
The CLUT decode applied the Saturn color-word **MSB rule backwards**:
- It treated **bit 15 set** as a CRAM color-bank index (looked up in Color RAM), and
- **bit 15 clear** as a direct RGB555 color.

The hardware is the opposite (VDP1 manual): **MSB set = a direct RGB555 color**, MSB clear = a CRAM color-bank index. Games routinely fill a CLUT with direct RGB colors (every entry MSB-set), so those sprites were decoded with bogus CRAM lookups instead of their actual colors.

Confirmed on a real PDS dump: the CLUT at `0x73E00` is `B18D AD8C AD6C …` — all MSB-set. `0xB18D` as RGB555 is (13,12,12) = grey (the stone wall), but the old code was indexing Color RAM with `entry & 0x7FF` and getting unrelated warm colors.

## Fix
In `DecodeTexel` (LUT_16 case): MSB set → `Rgb555ToRgba(entry)`; MSB clear → `CramColor(...)`.

## Verification
- Real PDS VDP1 dump now renders the corridor correctly — grey walls, red-topped character, dim lighting — matching the in-game reference (gouraud shading from #16 composes correctly on top of the now-correct base colors).
- **Battle3 render byte-identical** — its sprites don't use MSB-set LUT entries, so no regression.
- Native desktop + web (WASM) builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_