### PR TITLE
Yabause integration: one-command apply.py + self-contained frame gate

### DIFF
--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -12,7 +12,38 @@ calls. The memory export doesn't touch emulation logic; the optional pause/step
 gate only decides *when* a frame runs, never *how*, so it can't affect game
 compatibility.
 
-## 1. Copy three files into `yabause/src`
+## Recommended structure: a Yabause fork + `apply.py`
+
+Keep Saturn Explorer and Yabause as **separate repos** (Yabause is GPLv2; don't
+vendor its tree here). This directory holds the single source of truth for the
+integration — `se_export.{c,h}` and, via `../../Drivers/Common/src/SeLiveProtocol.h`,
+the wire protocol — plus `apply.py`, which drops those into a Yabause checkout and
+inserts the hook calls for you.
+
+```sh
+# 1. Fork Yabause once (github.com/Yabause/yabause -> your account) and clone it.
+git clone https://github.com/<you>/yabause.git
+cd yabause && git checkout -b saturn-explorer-live
+
+# 2. From this repo, wire your fork in one command:
+python3 /path/to/SaturnExplorer/Integration/Yabause/apply.py /path/to/yabause
+
+# 3. Commit the result on your fork's branch, then build Yabause as usual.
+git add -A && git commit -m "Add Saturn Explorer live tap"
+```
+
+`apply.py` is **idempotent** (safe to re-run after pulling upstream), inserts every
+edit inside `/* --- SE_EXPORT --- */` markers, and supports:
+- `--check` — report what it would change, touch nothing.
+- `--revert` — remove all edits and the copied files.
+
+When you update `se_export.*` here, re-run `apply.py` on your fork to sync. If a
+future Yabause refactor moves an anchor, the script says exactly which hook to add
+by hand — the manual steps below are that fallback.
+
+## Manual integration (fallback)
+
+### 1. Copy three files into `yabause/src`
 - `se_export.h`
 - `se_export.c`
 - `SeLiveProtocol.h`  ← from this repo's `Drivers/Common/src/SeLiveProtocol.h`
@@ -21,7 +52,7 @@ compatibility.
 Add `se_export.c` to Yabause's build (its `src/CMakeLists.txt` `yabause_SOURCES`
 list, or your Makefile). On Windows link against `ws2_32` if it isn't already.
 
-## 2. Wire in three calls
+### 2. Wire in the hook calls
 In `yabause/src/yabause.c`:
 
 ```c
@@ -55,22 +86,20 @@ globals (declared in `memory.h`). These names are stable across the Yabause fami
 if your fork renamed them, pass the equivalents. Any argument may be NULL to omit
 that section.
 
-## 2b. (Optional) Pause / single-step gate
+### 2b. (Optional) Pause / single-step gate
 To enable the Pause and Step Frame buttons, gate each emulated frame on
 `SeExportGateFrame()` in Yabause's run loop. It returns 1 when the frame should
-run and 0 while the debugger is holding it paused; release exactly one frame per
-call when single-stepping. In `yabause/src/yabause.c`, in `YabauseEmulate()` (or
-your port's per-frame loop), wrap the frame:
+run and 0 while the debugger is holding it paused (and releases exactly one frame
+per call when single-stepping). It sleeps ~2 ms internally when paused, so just
+spin on it — no host sleep needed. In `yabause/src/yabause.c`, at the top of
+`YabauseEmulate()`:
 
 ```c
 #include "se_export.h"
 
 int YabauseEmulate(void) {
-    /* ... at the top of the per-frame body, before running the frame: */
-    while (!SeExportGateFrame()) {
-        YabThreadUSleep(1000);      /* stay responsive to resume/step */
-        /* break here too on your loop's quit/reset condition */
-    }
+    int oneframeexec = 0;
+    while (!SeExportGateFrame()) { }   /* held here while paused */
     /* ... existing frame emulation ... */
 }
 ```

--- a/SaturnExplorer/Integration/Yabause/apply.py
+++ b/SaturnExplorer/Integration/Yabause/apply.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+apply.py — wire the Saturn Explorer live-tap into a Yabause checkout.
+
+Saturn Explorer keeps the export module (se_export.{c,h}) and the wire protocol
+(SeLiveProtocol.h) as the single source of truth in this repo. This script drops
+them into a Yabause tree and inserts the four small hook calls, so your fork
+stays a clean vanilla Yabause + a handful of clearly-marked edits.
+
+Usage:
+    python3 apply.py /path/to/yabause            # apply (or re-apply)
+    python3 apply.py /path/to/yabause --check     # report status, change nothing
+    python3 apply.py /path/to/yabause --revert    # remove the edits + copied files
+
+It is idempotent: every edit is fenced with `SE_EXPORT` markers, so running it
+again is a no-op, and --revert cleanly removes them. If an anchor can't be found
+(a Yabause fork moved the code), the script tells you exactly which hook to add
+by hand — see README.md for the manual diffs.
+
+Target layout assumed: <yabause>/yabause/src/{yabause.c,vdp2.c,CMakeLists.txt}.
+Pass the repo root; the script also accepts the src dir directly.
+"""
+
+import os
+import re
+import shutil
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# SeLiveProtocol.h lives with the drivers; keep one copy, copy it in on apply.
+PROTOCOL_SRC = os.path.normpath(os.path.join(HERE, "..", "..", "Drivers", "Common", "src", "SeLiveProtocol.h"))
+COPY_FILES = ["se_export.c", "se_export.h"]
+
+BEGIN = "/* --- SE_EXPORT (Saturn Explorer live tap) --- */"
+END = "/* --- end SE_EXPORT --- */"
+
+
+def fence(code):
+    return f"{BEGIN}\n{code}\n{END}"
+
+
+# Each edit: (filename, anchor regex, where to put the block relative to the
+# anchor ('after'|'before'), the C code to insert). Anchors are chosen to be
+# stable across Yabause versions; if one drifts, we report it precisely.
+EDITS = [
+    # --- yabause.c ---
+    ("yabause.c",
+     r'(\n)(int YabauseInit\s*\(yabauseinit_struct)',
+     "before_group2",
+     '#include "se_export.h"\n'),
+
+    ("yabause.c",
+     r'(scsp_set_use_new\(init->use_new_scsp\);\s*\n)(\s*return 0;)',
+     "between",
+     "   SeExportInit();   /* start the live-tap server */\n"),
+
+    ("yabause.c",
+     r'(void YabauseDeInit\(void\)\s*\{\s*\n)',
+     "after_group1",
+     "   SeExportDeinit();\n"),
+
+    ("yabause.c",
+     r'(int YabauseEmulate\(void\)\s*\{\s*\n\s*int oneframeexec = 0;\s*\n)',
+     "after_group1",
+     "   /* Frame gate: hold here while the debugger has us paused. The gate\n"
+     "    * sleeps internally and the export server thread keeps running, so a\n"
+     "    * resume/step from Saturn Explorer releases us. */\n"
+     "   while (!SeExportGateFrame()) { }\n"),
+
+    # --- vdp2.c ---
+    ("vdp2.c",
+     r'(#include "vdp2\.h"\n)',
+     "after_group1",
+     '#include "se_export.h"\n#include "memory.h"\n'),
+
+    ("vdp2.c",
+     r'(void Vdp2VBlankOUT\(void\)\s*\{[\s\S]*?static VideoInterface_struct \* saved = NULL;\s*\n)',
+     "after_group1",
+     "   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,\n"
+     "                    Vdp1Regs, LowWram, HighWram);\n"),
+]
+
+# CMakeLists is handled specially (add se_export.c to the source list).
+CMAKE_ANCHOR = re.compile(r'(\n\s*)(vdp1\.c vdp2\.c)')
+
+
+def find_src(root):
+    for cand in (os.path.join(root, "yabause", "src"), os.path.join(root, "src"), root):
+        if os.path.isfile(os.path.join(cand, "yabause.c")):
+            return cand
+    return None
+
+
+def already(text):
+    return BEGIN in text
+
+
+def apply_edit(text, anchor, mode, code):
+    """Insert fenced `code` at `anchor`. Returns (new_text, applied, found)."""
+    m = re.search(anchor, text)
+    if not m:
+        return text, False, False
+    block = fence(code.rstrip("\n")) + "\n"
+    if mode == "before_group2":
+        # keep group1 (a newline), insert before group2
+        ins = m.start(2)
+        return text[:ins] + block + text[ins:], True, True
+    if mode == "after_group1":
+        ins = m.end(1)
+        return text[:ins] + block + text[ins:], True, True
+    if mode == "between":
+        ins = m.end(1)
+        return text[:ins] + block + text[ins:], True, True
+    raise ValueError(mode)
+
+
+def process_file(src_dir, fname, do_write):
+    path = os.path.join(src_dir, fname)
+    if not os.path.isfile(path):
+        return [f"MISSING  {fname} (not found in {src_dir})"]
+    text = original = open(path, encoding="utf-8", errors="surrogateescape").read()
+    notes = []
+    for f, anchor, mode, code in EDITS:
+        if f != fname:
+            continue
+        tag = code.strip().splitlines()[0]
+        # Idempotency: skip if this exact code already fenced in.
+        if fence(code.rstrip("\n")) in text:
+            notes.append(f"  ok (already)  {tag}")
+            continue
+        text, applied, found = apply_edit(text, anchor, mode, code)
+        if applied:
+            notes.append(f"  + inserted    {tag}")
+        elif found:
+            notes.append(f"  ?             {tag}")
+        else:
+            notes.append(f"  ANCHOR MISS   {tag}  <-- add by hand (see README)")
+    if do_write and text != original:
+        open(path, "w", encoding="utf-8", errors="surrogateescape").write(text)
+    return notes
+
+
+def process_cmake(src_dir, do_write):
+    path = os.path.join(src_dir, "CMakeLists.txt")
+    if not os.path.isfile(path):
+        return ["MISSING  CMakeLists.txt"]
+    text = open(path, encoding="utf-8", errors="surrogateescape").read()
+    if "se_export.c" in text:
+        return ["  ok (already)  se_export.c in yabause_SOURCES"]
+    new, n = CMAKE_ANCHOR.subn(r"\1se_export.c \2", text, count=1)
+    if n == 0:
+        return ["  ANCHOR MISS   add se_export.c to yabause_SOURCES by hand"]
+    if do_write:
+        open(path, "w", encoding="utf-8", errors="surrogateescape").write(new)
+    return ["  + inserted    se_export.c into yabause_SOURCES"]
+
+
+def copy_sources(src_dir, do_write):
+    notes = []
+    files = [(os.path.join(HERE, f), f) for f in COPY_FILES] + [(PROTOCOL_SRC, "SeLiveProtocol.h")]
+    for srcpath, name in files:
+        if not os.path.isfile(srcpath):
+            notes.append(f"  MISSING SOURCE {srcpath}")
+            continue
+        dst = os.path.join(src_dir, name)
+        if do_write:
+            shutil.copyfile(srcpath, dst)
+        notes.append(f"  copy          {name}")
+    return notes
+
+
+def revert(src_dir):
+    fence_re = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END) + r"\n?", re.DOTALL)
+    for fname in ("yabause.c", "vdp2.c"):
+        path = os.path.join(src_dir, fname)
+        if os.path.isfile(path):
+            t = open(path, encoding="utf-8", errors="surrogateescape").read()
+            open(path, "w", encoding="utf-8", errors="surrogateescape").write(fence_re.sub("", t))
+    cpath = os.path.join(src_dir, "CMakeLists.txt")
+    if os.path.isfile(cpath):
+        t = open(cpath, encoding="utf-8", errors="surrogateescape").read()
+        open(cpath, "w", encoding="utf-8", errors="surrogateescape").write(t.replace("se_export.c vdp1.c", "vdp1.c"))
+    for f in COPY_FILES + ["SeLiveProtocol.h"]:
+        p = os.path.join(src_dir, f)
+        if os.path.isfile(p):
+            os.remove(p)
+    print("Reverted: removed SE_EXPORT edits and copied files.")
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a for a in sys.argv[1:] if a.startswith("--")}
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+    src_dir = find_src(args[0])
+    if not src_dir:
+        print(f"error: no yabause.c under {args[0]} (expected <root>/yabause/src).")
+        sys.exit(2)
+    print(f"Yabause src: {src_dir}")
+
+    if "--revert" in flags:
+        revert(src_dir)
+        return
+
+    do_write = "--check" not in flags
+    if not do_write:
+        print("(--check: reporting only, no files changed)\n")
+
+    notes = []
+    if do_write:
+        notes += copy_sources(src_dir, do_write)
+    for fname in ("yabause.c", "vdp2.c"):
+        notes.append(fname + ":")
+        notes += process_file(src_dir, fname, do_write)
+    notes.append("CMakeLists.txt:")
+    notes += process_cmake(src_dir, do_write)
+
+    print("\n".join(notes))
+    misses = [n for n in notes if "ANCHOR MISS" in n or "MISSING" in n]
+    if misses:
+        print("\nSome hooks need manual placement — see Integration/Yabause/README.md.")
+        sys.exit(3)
+    print("\nDone. Build Yabause as usual; Saturn Explorer can now connect (--live).")
+
+
+if __name__ == "__main__":
+    main()

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -2,6 +2,12 @@
  * Self-contained: only needs SeLiveProtocol.h (copy it in from
  * Drivers/Common/src/) and the platform's sockets/threads. */
 
+/* Ask glibc to declare usleep() from <unistd.h> even under strict -std=c11
+ * (must precede any system header). */
+#if !defined(_WIN32) && !defined(_DEFAULT_SOURCE)
+#define _DEFAULT_SOURCE 1
+#endif
+
 #include "se_export.h"
 #include "SeLiveProtocol.h"
 
@@ -75,11 +81,25 @@ static volatile int sPaused;
 static volatile int sStepBudget;
 static volatile unsigned long long sFrameNo;
 
+/* Short self-contained sleep so the gate can spin-wait without a Yabause-
+ * specific sleep primitive and without pegging a CPU core while paused. */
+static void SeGateSleep(void)
+{
+#if defined(_WIN32)
+    Sleep(2);
+#else
+    usleep(2000);
+#endif
+}
+
 /* Called by the emulator's run loop at the top of each frame: returns 1 if the
  * frame should run, 0 if the debugger is holding it paused. When paused with a
- * pending single-step budget, it releases exactly one frame per call. The host
- * should sleep briefly and re-check when this returns 0 (so it stays responsive
- * to a later resume/step). Safe to call even before SeExportInit (returns 1). */
+ * pending single-step budget, it releases exactly one frame per call. When it
+ * would return 0 it first sleeps ~2 ms internally, so the caller can simply spin
+ *   while (!SeExportGateFrame()) { }
+ * without its own sleep and without busy-pegging a core. The export server
+ * thread keeps running, so a resume/step from Saturn Explorer releases the loop.
+ * Safe to call even before SeExportInit (returns 1). */
 int SeExportGateFrame(void)
 {
     if (!sPaused)
@@ -91,6 +111,7 @@ int SeExportGateFrame(void)
         --sStepBudget;
         return 1;
     }
+    SeGateSleep();
     return 0;
 }
 

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -39,8 +39,9 @@ void SeExportSnapshot(const void* vdp1_vram_512k, const void* vdp2_vram_512k,
 
 /* Frame gate for pause / single-step. Call once at the top of each emulated
  * frame in Yabause's run loop; returns 1 if the frame should run, 0 if the
- * debugger is holding it paused (sleep briefly and re-check, e.g.):
- *   while (!SeExportGateFrame()) { YabThreadUSleep(1000); if (quitting) break; }
+ * debugger is holding it paused. When it returns 0 it has already slept ~2 ms
+ * internally, so just spin on it — no host sleep needed:
+ *   while (!SeExportGateFrame()) { }
  * When resumed or single-stepped from Saturn Explorer, it releases frames again.
  * Returns 1 when the server isn't running, so an un-paused build is unaffected. */
 int SeExportGateFrame(void);


### PR DESCRIPTION
Sets up a clean structure for maintaining the live-tap in a **Yabause fork**, without vendoring Yabause's GPLv2 tree into this repo.

## Structure
`Integration/Yabause/` stays the single source of truth for the integration — `se_export.{c,h}` and (via `Drivers/Common/src/SeLiveProtocol.h`) the wire protocol — and now ships an applier so a fork is one command to wire up:

```sh
python3 SaturnExplorer/Integration/Yabause/apply.py /path/to/yabause
```

- **`apply.py`** copies the three files into the Yabause checkout and inserts the four hook calls (`SeExportInit`, `SeExportDeinit`, the `Vdp2VBlankOUT` snapshot, and the run-loop frame gate) plus the CMake source entry. It's **idempotent** (safe to re-run after pulling upstream), fences every edit in `/* --- SE_EXPORT --- */` markers, and supports `--check` (dry run) and `--revert` (clean removal). If a future Yabause refactor moves an anchor, it reports exactly which hook to place by hand.
- **Self-contained gate**: `SeExportGateFrame()` now sleeps ~2 ms internally when paused, so the run-loop hook is simply `while (!SeExportGateFrame()) { }` — no dependency on Yabause's threading API (the old `YabThreadUSleep` example referenced a function that doesn't exist in Yabause). Also requests `_DEFAULT_SOURCE` so `usleep()` is declared under strict `-std=c11`.
- **README** now leads with the fork + `apply.py` workflow; the manual diffs remain as a fallback with the gate snippet corrected.

## Verification
- Ran `apply.py` against current upstream Yabause (`yabause.c`, `vdp2.c`, `CMakeLists.txt`): **all anchors match**, edits land in the correct places, re-runs are no-ops, `--revert` is clean. Confirmed the referenced symbols exist (`LowWram`/`HighWram` in `memory.h`, `Vdp1Ram`/`Vdp1Regs` in `vdp1.h`).
- `se_export.c` compiles clean with `-Wall -Wextra -Werror` under `-std=c11`.
- Rebuilt the mock Yabause against the updated module; **live pause / single-step / resume still pass** over the ABI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_