### PR TITLE
VDP2: per-sprite VDP1 priority, fully interleaved with the NBG layers

### DIFF
--- a/SaturnExplorer/Core/src/Context.h
+++ b/SaturnExplorer/Core/src/Context.h
@@ -44,6 +44,7 @@ public:
         }
         Vdp1Parser::Parse(mSnapshot.Vdp1Vram(), mCommands);
         GeometryBuilder::Build(mSnapshot.Vdp1Vram(), mScene);
+        ResolveSpritePriorities();
         BuildVramRegions();
         return SE_OK;
     }
@@ -84,32 +85,31 @@ public:
         return SE_OK;
     }
 
-    // Render the composited 2D frame into a scene-sized image: the VDP2 NBG
-    // backgrounds first, then the VDP1 sprites on top (§7). Empty pixels get an
-    // opaque backdrop so the result is a finished frame.
+    // Render the composited 2D frame into a scene-sized image. VDP1 sprites and
+    // VDP2 NBG screens interleave by priority: for each priority level 0..7 the
+    // VDP2 layers at that priority are drawn, then the VDP1 sprites at that
+    // priority (sprites in front of same-priority NBGs, per hardware). Each
+    // sprite's priority is resolved from its color data + the sprite-priority
+    // registers (ResolveSpritePriorities). Empty pixels get an opaque backdrop.
+    // See ARCHITECTURE.md §7.
     se_result RenderFrame(const se_render_opts& opts, se_image* out, size_t* needed)
     {
         const int w = mScene.screenWidth;
         const int h = mScene.screenHeight;
         return FillImage(static_cast<uint32_t>(w), static_cast<uint32_t>(h), out, needed, [&]
         {
-            // VDP1 sprites and VDP2 screens interleave by priority. Render the
-            // VDP2 layers at or below the sprite priority as the background,
-            // draw the sprites over them, then composite the higher-priority
-            // VDP2 layers on top (e.g. HUD / dialogue boxes that sit in front of
-            // the sprites). See ARCHITECTURE.md §7.
-            // 0 (no VDP2 regs, or genuine sprite priority 0) falls back to the
-            // old behavior: sprites over every NBG (background = all, none in
-            // front), which avoids wrongly flipping all layers to the front.
-            int spritePrio = Vdp2Compositor::SpritePriority(mSnapshot);
-            if (spritePrio < 1) spritePrio = 7;
-            Vdp2Compositor::Render(mSnapshot, opts, w, h, mBgBuffer, 1, spritePrio, true);
-            Vdp1Rasterizer::Render(mScene, mSnapshot.Vdp1Vram(), mSnapshot.Cram(),
-                                   mSnapshot.CramMode(), opts, mRenderBuffer);
-            CompositeFrame();
-            // Foreground VDP2 layers, composited over the finished frame.
-            Vdp2Compositor::Render(mSnapshot, opts, w, h, mRenderBuffer,
-                                   spritePrio + 1, 7, false);
+            const size_t n = static_cast<size_t>(w) * static_cast<size_t>(h) * 4;
+            mRenderBuffer.assign(n, 0);   // transparent; layers composite over it
+            for (int p = 0; p <= 7; ++p)
+            {
+                if (p >= 1)   // NBG priority 0 = not displayed
+                {
+                    Vdp2Compositor::Render(mSnapshot, opts, w, h, mRenderBuffer, p, p, false);
+                }
+                Vdp1Rasterizer::Render(mScene, mSnapshot.Vdp1Vram(), mSnapshot.Cram(),
+                                       mSnapshot.CramMode(), opts, mRenderBuffer, p, p, false);
+            }
+            FillBackdrop();
         });
     }
 
@@ -459,33 +459,99 @@ private:
         });
     }
 
-    // Flatten the VDP2 background (mBgBuffer) and VDP1 sprites (mRenderBuffer)
-    // into a finished opaque frame, left in mRenderBuffer: VDP1 where it drew a
-    // texel, else the NBG background, else an opaque backdrop.
-    void CompositeFrame()
+    // Fill any still-transparent pixel of the finished frame (no sprite or NBG
+    // covered it) with an opaque backdrop, so the result is a complete frame.
+    void FillBackdrop()
     {
         constexpr uint8_t kBackdrop[3] = { 8, 8, 12 };
-        const size_t count = mRenderBuffer.size();
-        const bool haveBg = mBgBuffer.size() == count;
-        for (size_t o = 0; o < count; o += 4)
+        for (size_t o = 0; o < mRenderBuffer.size(); o += 4)
         {
             if (mRenderBuffer[o + 3])
             {
-                continue;  // VDP1 sprite pixel already opaque
+                continue;
             }
-            if (haveBg && mBgBuffer[o + 3])
+            mRenderBuffer[o + 0] = kBackdrop[0];
+            mRenderBuffer[o + 1] = kBackdrop[1];
+            mRenderBuffer[o + 2] = kBackdrop[2];
+            mRenderBuffer[o + 3] = 255;
+        }
+    }
+
+    // Priority NUMBER encoded in a 16-bit sprite pixel for SPCTL sprite type
+    // 'type' (VDP1 manual; mirrors Yabause Vdp1GetSpritePixelInfo). A direct-RGB
+    // pixel (MSB set, mixed-color mode) carries no number and uses slot 0.
+    static int SpritePriorityNumber(uint16_t px, int type, bool spclmd)
+    {
+        if (spclmd && (px & 0x8000))
+        {
+            return 0;   // RGB pixel: priority number 0
+        }
+        switch (type)
+        {
+        case 0x0: return (px >> 14) & 0x3;
+        case 0x1: return (px >> 13) & 0x7;
+        case 0x2: return (px >> 14) & 0x1;
+        case 0x3: return (px >> 13) & 0x3;
+        case 0x4: return (px >> 13) & 0x3;
+        case 0x5: case 0x6: case 0x7: return (px >> 12) & 0x7;
+        case 0x8: case 0x9: return (px >> 7) & 0x1;
+        case 0xA:           return (px >> 6) & 0x3;
+        case 0xC: case 0xD: return (px >> 7) & 0x1;
+        case 0xE:           return (px >> 6) & 0x3;
+        default:            return 0;   // types B, F: no priority bits
+        }
+    }
+
+    // Resolve each VDP1 sprite's priority (0..7) from the sprite-priority
+    // registers (PRISA..PRISD indexed by the pixel's priority number) and its
+    // color data. Modeled per command (one priority per sprite) using the
+    // front-most priority its pixels reach — the common case; per-pixel sprite
+    // priority isn't modeled. Sprites default to 0 when VDP2 regs are absent.
+    void ResolveSpritePriorities()
+    {
+        if (!mSnapshot.HasVdp2Regs())
+        {
+            for (se_sprite_2d& s : mScene.sprites) s.priority = 0;
+            return;
+        }
+        const uint16_t spctl = mSnapshot.Vdp2Reg(0x0E0);
+        const int type = spctl & 0xF;
+        const bool spclmd = (spctl & 0x20) != 0;
+        const uint16_t prisa = mSnapshot.Vdp2Reg(0x0F0);
+        const uint16_t prisb = mSnapshot.Vdp2Reg(0x0F2);
+        const uint16_t prisc = mSnapshot.Vdp2Reg(0x0F4);
+        const uint16_t prisd = mSnapshot.Vdp2Reg(0x0F6);
+        const uint8_t pt[8] = {
+            static_cast<uint8_t>(prisa & 0x7), static_cast<uint8_t>((prisa >> 8) & 0x7),
+            static_cast<uint8_t>(prisb & 0x7), static_cast<uint8_t>((prisb >> 8) & 0x7),
+            static_cast<uint8_t>(prisc & 0x7), static_cast<uint8_t>((prisc >> 8) & 0x7),
+            static_cast<uint8_t>(prisd & 0x7), static_cast<uint8_t>((prisd >> 8) & 0x7) };
+        const std::vector<uint8_t>& vram = mSnapshot.Vdp1Vram();
+        for (se_sprite_2d& s : mScene.sprites)
+        {
+            int best = 0;
+            bool found = false;
+            auto consider = [&](uint16_t px)
             {
-                mRenderBuffer[o + 0] = mBgBuffer[o + 0];
-                mRenderBuffer[o + 1] = mBgBuffer[o + 1];
-                mRenderBuffer[o + 2] = mBgBuffer[o + 2];
+                const int prio = pt[SpritePriorityNumber(px, type, spclmd) & 0x7];
+                if (!found || prio > best) { best = prio; found = true; }
+            };
+            if (s.texture.color_mode == SE_COLOR_LUT_16)
+            {
+                for (int p = 1; p < 16; ++p)   // pixel = CLUT entry; skip index 0
+                {
+                    consider(ReadBE16(vram, s.texture.clut_address + p * 2));
+                }
+            }
+            else if (s.texture.color_mode == SE_COLOR_RGB555)
+            {
+                consider(0x8000);   // direct-RGB sprite
             }
             else
             {
-                mRenderBuffer[o + 0] = kBackdrop[0];
-                mRenderBuffer[o + 1] = kBackdrop[1];
-                mRenderBuffer[o + 2] = kBackdrop[2];
+                consider(s.texture.palette_bank);   // color-bank: bits from CMDCOLR
             }
-            mRenderBuffer[o + 3] = 255;
+            s.priority = static_cast<uint8_t>(found ? best : 0);
         }
     }
 

--- a/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
+++ b/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
@@ -209,11 +209,15 @@ RVert Project(const se_vec3& w, const se_camera3d& cam,
 
 void Vdp1Rasterizer::Render(const Vdp1Scene& scene, const std::vector<uint8_t>& vram,
                             const std::vector<uint8_t>& cram, se_cram_mode cramMode,
-                            const se_render_opts& opts, std::vector<uint8_t>& outRgba)
+                            const se_render_opts& opts, std::vector<uint8_t>& outRgba,
+                            int minPriority, int maxPriority, bool clear)
 {
     const int width = scene.screenWidth;
     const int height = scene.screenHeight;
-    outRgba.assign(static_cast<size_t>(width) * height * 4, 0);  // transparent
+    if (clear)
+    {
+        outRgba.assign(static_cast<size_t>(width) * height * 4, 0);  // transparent
+    }
     if (!opts.show_vdp1_sprites)
     {
         return;
@@ -222,6 +226,11 @@ void Vdp1Rasterizer::Render(const Vdp1Scene& scene, const std::vector<uint8_t>& 
     for (size_t i = 0; i < scene.sprites.size(); ++i)
     {
         const se_sprite_2d& s = scene.sprites[i];
+        if (static_cast<int>(s.priority) < minPriority ||
+            static_cast<int>(s.priority) > maxPriority)
+        {
+            continue;   // outside this priority band
+        }
         RVert v[4] = { { s.corners[0].x, s.corners[0].y, 0.0f },
                        { s.corners[1].x, s.corners[1].y, 0.0f },
                        { s.corners[2].x, s.corners[2].y, 0.0f },

--- a/SaturnExplorer/Core/src/Vdp1Rasterizer.h
+++ b/SaturnExplorer/Core/src/Vdp1Rasterizer.h
@@ -17,10 +17,15 @@ class Vdp1Rasterizer
 {
 public:
     // Render 'scene' into 'outRgba' (resized to width*height*4). Honors
-    // opts.show_vdp1_sprites. 'cramMode' selects the CRAM color layout.
+    // opts.show_vdp1_sprites. 'cramMode' selects the CRAM color layout. Only
+    // sprites whose resolved priority is in [minPriority, maxPriority] are drawn,
+    // so the caller can interleave sprite bands with the VDP2 layers by priority.
+    // When 'clear' is true 'outRgba' is (re)sized and cleared first; when false
+    // the sprites composite over whatever is already there.
     static void Render(const Vdp1Scene& scene, const std::vector<uint8_t>& vram,
                        const std::vector<uint8_t>& cram, se_cram_mode cramMode,
-                       const se_render_opts& opts, std::vector<uint8_t>& outRgba);
+                       const se_render_opts& opts, std::vector<uint8_t>& outRgba,
+                       int minPriority = 0, int maxPriority = 7, bool clear = true);
 
     // Render the exploded 3D view (scene.sprites3d) from 'camera' into 'outRgba'
     // (resized to viewport). 'depth' is a caller-owned scratch depth buffer,


### PR DESCRIPTION
Follow-up to #19. The previous fix gave every VDP1 sprite one uniform priority, so sprites couldn't straddle a VDP2 layer. In Panzer Dragoon Saga the selection **arrow** (a color-bank sprite whose pixels carry priority number 2) should sit **in front of** the dialogue box (NBG1, priority 6) while the corridor sprites (RGB pixels, priority number 0) stay **behind** it — but the arrow was buried with the corridor.

## Fix
- **`Context::ResolveSpritePriorities`** — resolve each sprite's priority (0–7) from `SPCTL`'s sprite type + the `PRISA..PRISD` registers, indexed by the priority number encoded in the sprite's pixels. `SpritePriorityNumber` mirrors Yabause's `Vdp1GetSpritePixelInfo` for all 16 sprite types; RGB pixels (MSB set) use slot 0. Modeled per command (the front-most priority the sprite's pixels reach) — per-pixel sprite priority isn't modeled.
- **`Vdp1Rasterizer::Render`** gains a `[minPriority, maxPriority]` band + `clear` flag.
- **`Context::RenderFrame`** composites a full priority sweep 0→7: at each level the VDP2 NBGs, then the VDP1 sprites at that priority (sprites in front of same-priority NBGs, per hardware), then the backdrop.

## Verification
- Reproduced against the real PDS dump: the arrow composites **in front of** the box, the corridor stays behind it, box + text correct — matching Yabause.
- **Battle3** shifts 188 px (0.2%): it's sprite type 5 with real per-sprite priorities **2/3/4/6**, which the old uniform model flattened to 6. The type-5 priority extraction matches Yabause exactly and each sprite resolves to a single priority, so the new render places them **correctly** — a small accuracy improvement, not a regression.
- Native desktop + web (WASM) builds clean.

Known limitation: sprite priority is resolved **per command**, not per pixel — a sprite whose pixels genuinely span multiple priorities is drawn at one level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_