### PR TITLE
Frontend: auto-connect to Yabause on boot + aspect-fit viewport

### DIFF
--- a/SaturnExplorer/FrontEnd/Platforms/Web/WebMain.cpp
+++ b/SaturnExplorer/FrontEnd/Platforms/Web/WebMain.cpp
@@ -83,11 +83,12 @@ int main(int argc, char** argv)
     // main() does not return and tear down the context.
     emscripten_set_main_loop(FrameOnce, 0, 1);
 #else
-    // Native (desktop) convenience: `--live [endpoint]` connects to a running
-    // Yabause; otherwise a savestate/dump path loads it (no browser picker here).
+    // Native (desktop): auto-connect to a running Yabause on boot (retrying until
+    // one appears). `--live [endpoint]` picks a specific endpoint; a savestate/dump
+    // path instead loads that file and disables auto-connect.
     if (argc > 1 && std::strcmp(argv[1], "--live") == 0)
     {
-        gApp.OpenLive(argc > 2 ? argv[2] : nullptr);
+        gApp.EnableLiveAutoConnect(argc > 2 ? argv[2] : nullptr);
     }
     else if (argc > 1)
     {
@@ -106,6 +107,10 @@ int main(int argc, char** argv)
             }
             std::fclose(f);
         }
+    }
+    else
+    {
+        gApp.EnableLiveAutoConnect(nullptr);   // no args: poll for Yabause on boot
     }
     while (gPlatform.PumpEvents())
     {

--- a/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
+++ b/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
@@ -22,16 +22,20 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
     sfe::App app;
     app.Initialize();
 
-    // `--live [endpoint]` connects to a running Yabause on startup (see the
-    // Integration/Yabause module). Otherwise the user opens files from the toolbar.
+    // Auto-connect to a running Yabause on boot, retrying until one appears
+    // (see the Integration/Yabause module). `--live [endpoint]` picks a specific
+    // endpoint; otherwise the default socket/pipe is polled. Files open from the
+    // toolbar and stop the polling.
+    const char* liveEndpoint = nullptr;
     for (int i = 1; i < __argc; ++i)
     {
         if (std::strcmp(__argv[i], "--live") == 0)
         {
-            app.OpenLive((i + 1 < __argc) ? __argv[i + 1] : nullptr);
+            liveEndpoint = (i + 1 < __argc) ? __argv[i + 1] : nullptr;
             break;
         }
     }
+    app.EnableLiveAutoConnect(liveEndpoint);
 
     while (platform.PumpEvents())
     {

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -313,6 +313,17 @@ bool App::OpenLive(const char* endpoint)
 #endif
 }
 
+void App::EnableLiveAutoConnect(const char* endpoint)
+{
+#ifdef SE_ENABLE_LIVE
+    mbAutoConnectLive = true;
+    mLiveEndpoint = endpoint ? endpoint : "";
+    mLiveRetrySeconds = 1.0f;   // attempt on the very first frame
+#else
+    (void)endpoint;
+#endif
+}
+
 bool App::OpenSavestateBuffer(const uint8_t* data, size_t size)
 {
     CloseData();
@@ -334,6 +345,21 @@ bool App::OpenSavestateBuffer(const uint8_t* data, size_t size)
 
 void App::BuildUI(IPlatform& platform)
 {
+#ifdef SE_ENABLE_LIVE
+    // Auto-connect: while nothing is loaded, retry the live endpoint about once a
+    // second so the app latches onto a Yabause as soon as one starts. se_live_open
+    // fails fast when no server is listening, so a failed poll is cheap.
+    if (mbAutoConnectLive && !mbHasData)
+    {
+        mLiveRetrySeconds += ImGui::GetIO().DeltaTime;
+        if (mLiveRetrySeconds >= 1.0f)
+        {
+            mLiveRetrySeconds = 0.0f;
+            OpenLive(mLiveEndpoint.empty() ? nullptr : mLiveEndpoint.c_str());
+        }
+    }
+#endif
+
     // A live source changes every frame: re-snapshot before anything reads it, so
     // all panels reflect the running emulator's current VDP state. (Static sources
     // snapshot once at load, in CreateContextFromSource.)
@@ -649,14 +675,26 @@ void App::DrawVdpOutput(IPlatform& platform)
         }
         else
         {
+            // Fit the frame to the panel, preserving aspect ratio (scale by the
+            // tighter of the two axes) and centering it — letterbox/pillarbox,
+            // like a 3D editor viewport.
             const ImVec2 avail = ImGui::GetContentRegionAvail();
-            float scale = (mFrameWidth > 0) ? avail.x / static_cast<float>(mFrameWidth) : 1.0f;
-            if (scale <= 0.0f)
+            float scale = 1.0f;
+            if (mFrameWidth > 0 && mFrameHeight > 0)
             {
-                scale = 1.0f;
+                const float sx = avail.x / static_cast<float>(mFrameWidth);
+                const float sy = avail.y / static_cast<float>(mFrameHeight);
+                scale = sx < sy ? sx : sy;
+                if (scale <= 0.0f)
+                {
+                    scale = 1.0f;
+                }
             }
-            const ImVec2 imgPos = ImGui::GetCursorScreenPos();
             const ImVec2 dispSize(mFrameWidth * scale, mFrameHeight * scale);
+            const ImVec2 origin = ImGui::GetCursorScreenPos();
+            ImGui::SetCursorScreenPos(ImVec2(origin.x + (avail.x - dispSize.x) * 0.5f,
+                                             origin.y + (avail.y - dispSize.y) * 0.5f));
+            const ImVec2 imgPos = ImGui::GetCursorScreenPos();
             ImGui::Image(mFrameTexture, dispSize);
 
             ImDrawList* dl = ImGui::GetWindowDrawList();

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "saturnexplorer/SaturnExplorer.h"
@@ -34,6 +35,11 @@ public:
     // for the platform default socket. No-op returning false unless the build was
     // compiled with the LiveDriver (SE_ENABLE_LIVE — native desktop / Windows).
     bool OpenLive(const char* endpoint);
+
+    // Keep trying to connect to a running Yabause on 'endpoint' (NULL = default)
+    // roughly once a second until something is loaded. Call once on startup so the
+    // app latches onto an emulator the moment it appears. No-op on web builds.
+    void EnableLiveAutoConnect(const char* endpoint);
 
     // Draw the whole UI. Called once per frame, between the platform's
     // BeginFrame and EndFrame.
@@ -76,6 +82,9 @@ private:
     se_render_opts   mRenderOpts {};
     bool             mbLiveSource = false;    // data comes from a running emulator
     bool             mbPaused = false;        // live emulator held paused (frame control)
+    bool             mbAutoConnectLive = false; // poll for a Yabause until one loads
+    std::string      mLiveEndpoint;           // endpoint for auto-connect (empty = default)
+    float            mLiveRetrySeconds = 0.0f; // time since the last connect attempt
     int              mSelectedCommand = -1;   // primary selection (detail panels)
     std::vector<int> mSelection;              // all selected command indices
     bool             mbLayoutBuilt = false;   // default dock layout applied once


### PR DESCRIPTION
Two frontend UX improvements from the next-steps list.

## Auto-connect on boot
On native startup the app polls the live endpoint about once a second until a running Yabause appears (or a file is loaded), so it latches on the moment the emulator starts — no manual "Connect" needed. `se_live_open` fails fast when nothing is listening, so each poll is cheap.
- `EnableLiveAutoConnect(endpoint)` sets it up; `BuildUI` drives the retry off the frame delta and stops once anything is loaded.
- `--live [endpoint]` selects a specific endpoint; a savestate/dump path loads that file instead and disables polling.
- Wired into the desktop (`WebMain`) and Windows mains. No-op on web builds (`SE_ENABLE_LIVE` guarded).

## Aspect-fit viewport
The VDP Output now fits the frame to the panel **preserving aspect ratio** (scaling by the tighter axis) and centers it — letterbox/pillarbox, like a 3D editor viewport — so the whole frame is always visible instead of scaling by width and clipping the bottom. Overlays and click hit-testing use the centered origin + scale, so selection still maps correctly. The 3D view already renders at the panel's size/aspect.

## Verification
- Headless: launched with **no args** against a running mock Yabause, the app auto-connected within a second and rendered the scene; the 2D view is centered and aspect-correct (full frame visible with pillarbox bars).
- Native desktop + web (WASM) builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_