### PR TITLE
Live: fix "connected but no data" — version-tolerant snapshot parse + apply.py hook update-in-place

### DIFF
--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
@@ -223,26 +223,38 @@ bool ReadSnapshot(Conn& c, const char* verb, int32_t arg, LiveSnapshot& snap,
     {
         return false;
     }
-    uint8_t hdr[SE_LIVE_HEADER_LEN];
-    if (!ConnReadFull(c, hdr, sizeof(hdr)))
+    // Read magic + version first, then size the section-length table to the
+    // server's version so we stay in sync with either a v3 (no VDP1 frame buffer,
+    // 8 sections) or v4+ (adds the FB, 9 sections) server. This keeps a rebuilt
+    // (v4) client working against a not-yet-rebuilt (v3) Yabause: it just reports
+    // fb == 0 and the FB read below becomes a no-op.
+    uint8_t head[8];
+    if (!ConnReadFull(c, head, sizeof(head)))
     {
         return false;
     }
-    if (hdr[0] != SE_LIVE_MAGIC0 || hdr[1] != SE_LIVE_MAGIC1 ||
-        hdr[2] != SE_LIVE_MAGIC2 || hdr[3] != SE_LIVE_MAGIC3)
+    if (head[0] != SE_LIVE_MAGIC0 || head[1] != SE_LIVE_MAGIC1 ||
+        head[2] != SE_LIVE_MAGIC2 || head[3] != SE_LIVE_MAGIC3)
     {
         return false;
     }
-    // hdr[4..7] version (unused beyond presence for now)
-    const uint32_t v1 = Rd32LE(hdr + 8);
-    const uint32_t v2 = Rd32LE(hdr + 12);
-    const uint32_t cr = Rd32LE(hdr + 16);
-    const uint32_t vs = Rd32LE(hdr + 20);
-    const uint32_t vr = Rd32LE(hdr + 24);
-    const uint32_t wl = Rd32LE(hdr + 28);
-    const uint32_t wh = Rd32LE(hdr + 32);
-    const uint32_t fb = Rd32LE(hdr + 36);
-    const uint32_t ct = Rd32LE(hdr + 40);
+    const uint32_t version = Rd32LE(head + 4);
+    const int hasFb = (version >= 4u) ? 1 : 0;    // FB section added in v4
+    const int numLen = 8 + hasFb;                 // section-length entries
+    uint8_t lens[9 * 4];
+    if (!ConnReadFull(c, lens, static_cast<size_t>(numLen) * 4))
+    {
+        return false;
+    }
+    const uint32_t v1 = Rd32LE(lens + 0);
+    const uint32_t v2 = Rd32LE(lens + 4);
+    const uint32_t cr = Rd32LE(lens + 8);
+    const uint32_t vs = Rd32LE(lens + 12);
+    const uint32_t vr = Rd32LE(lens + 16);
+    const uint32_t wl = Rd32LE(lens + 20);
+    const uint32_t wh = Rd32LE(lens + 24);
+    const uint32_t fb = hasFb ? Rd32LE(lens + 28) : 0u;
+    const uint32_t ct = Rd32LE(lens + (hasFb ? 32 : 28));
     // Sanity clamps so a malformed header can't drive a huge allocation.
     if (v1 > 0x100000u || v2 > 0x100000u || cr > 0x4000u || vs > 4096u ||
         vr > 256u || wl > 0x100000u || wh > 0x100000u || fb > 0x40000u || ct > 64u)

--- a/SaturnExplorer/Integration/Yabause/apply.py
+++ b/SaturnExplorer/Integration/Yabause/apply.py
@@ -40,24 +40,31 @@ def fence(code):
 
 
 # Each edit: (filename, anchor regex, where to put the block relative to the
-# anchor ('after'|'before'), the C code to insert). Anchors are chosen to be
+# anchor ('after'|'before'), the C code to insert, key). 'key' is a stable
+# substring that identifies this hook regardless of its exact text — so when the
+# hook's content changes (e.g. SeExportSnapshot gains an argument), re-running
+# updates the existing fenced block in place instead of inserting a second copy
+# (which would leave a stale, no-longer-compiling call). Anchors are chosen to be
 # stable across Yabause versions; if one drifts, we report it precisely.
 EDITS = [
     # --- yabause.c ---
     ("yabause.c",
      r'(\n)(int YabauseInit\s*\(yabauseinit_struct)',
      "before_group2",
-     '#include "se_export.h"\n'),
+     '#include "se_export.h"\n',
+     '#include "se_export.h"'),
 
     ("yabause.c",
      r'(scsp_set_use_new\(init->use_new_scsp\);\s*\n)(\s*return 0;)',
      "between",
-     "   SeExportInit();   /* start the live-tap server */\n"),
+     "   SeExportInit();   /* start the live-tap server */\n",
+     "SeExportInit("),
 
     ("yabause.c",
      r'(void YabauseDeInit\(void\)\s*\{\s*\n)',
      "after_group1",
-     "   SeExportDeinit();\n"),
+     "   SeExportDeinit();\n",
+     "SeExportDeinit("),
 
     ("yabause.c",
      r'(int YabauseEmulate\(void\)\s*\{\s*\n\s*int oneframeexec = 0;\s*\n)',
@@ -65,20 +72,26 @@ EDITS = [
      "   /* Frame gate: hold here while the debugger has us paused. The gate\n"
      "    * sleeps internally and the export server thread keeps running, so a\n"
      "    * resume/step from Saturn Explorer releases us. */\n"
-     "   while (!SeExportGateFrame()) { }\n"),
+     "   while (!SeExportGateFrame()) { }\n",
+     "SeExportGateFrame("),
 
     # --- vdp2.c ---
     ("vdp2.c",
      r'(#include "vdp2\.h"\n)',
      "after_group1",
-     '#include "se_export.h"\n#include "memory.h"\n'),
+     '#include "se_export.h"\n#include "memory.h"\n',
+     '#include "se_export.h"'),
 
     ("vdp2.c",
      r'(void Vdp2VBlankOUT\(void\)\s*\{[\s\S]*?static VideoInterface_struct \* saved = NULL;\s*\n)',
      "after_group1",
      "   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,\n"
-     "                    Vdp1Regs, LowWram, HighWram, Vdp1FrameBuffer[0]);\n"),
+     "                    Vdp1Regs, LowWram, HighWram, Vdp1FrameBuffer[0]);\n",
+     "SeExportSnapshot("),
 ]
+
+# A fenced SE_EXPORT block (for update-in-place when a hook's content changes).
+FENCE_RE = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END), re.DOTALL)
 
 # CMakeLists is handled specially (add se_export.c to the source list).
 CMAKE_ANCHOR = re.compile(r'(\n\s*)(vdp1\.c vdp2\.c)')
@@ -120,13 +133,21 @@ def process_file(src_dir, fname, do_write):
         return [f"MISSING  {fname} (not found in {src_dir})"]
     text = original = open(path, encoding="utf-8", errors="surrogateescape").read()
     notes = []
-    for f, anchor, mode, code in EDITS:
+    for f, anchor, mode, code, key in EDITS:
         if f != fname:
             continue
         tag = code.strip().splitlines()[0]
-        # Idempotency: skip if this exact code already fenced in.
-        if fence(code.rstrip("\n")) in text:
-            notes.append(f"  ok (already)  {tag}")
+        new_block = fence(code.rstrip("\n"))
+        # If a fenced block for this hook already exists (matched by its stable
+        # key), update it in place — so a changed hook (e.g. a new argument) is
+        # replaced, not duplicated. Exact match => nothing to do.
+        existing = next((m.group(0) for m in FENCE_RE.finditer(text) if key in m.group(0)), None)
+        if existing is not None:
+            if existing == new_block:
+                notes.append(f"  ok (already)  {tag}")
+            else:
+                text = text.replace(existing, new_block, 1)
+                notes.append(f"  ~ updated     {tag}")
             continue
         text, applied, found = apply_edit(text, anchor, mode, code)
         if applied:


### PR DESCRIPTION
Fixes the "connected to Yabause but no image / frame stuck at 0" regression after rebuilding only one side.

**Cause:** the v4 protocol added a VDP1 frame-buffer section (44-byte header, 9 sections). The client read a fixed 44-byte / 9-section header and ignored the version field, so a rebuilt **v4 client against a still-v3 Yabause** (client rebuilt, emulator not) read 4 bytes of VRAM as the control length, failed the sanity check every frame, and showed no data.

**Fix:**
- **Version-tolerant parse:** the client reads magic + version first and sizes the section-length table to the server's version. A v3 server (8 sections, no FB) reports `fb=0` and the FB read becomes a no-op, so a v4 client works against **either** Yabause build.
- **apply.py hook update-in-place:** each hook carries a stable key, so re-applying after a hook signature change (`SeExportSnapshot` gaining the `Vdp1FrameBuffer` arg) updates the existing fenced block instead of inserting a second, stale copy that wouldn't compile.

**Verification:** the real LiveDriver streams frames and reads VDP1 VRAM/FB correctly from both a v3 mock (`fb=0`) and a v4 mock (`fb=4B`) over TCP; apply.py re-apply updates the 7-arg hook to 8-arg with a single occurrence. Desktop builds clean; `se_export.c` compiles as C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_