### PR TITLE
Live: show protocol version + flag client/emulator version mismatch

### DIFF
--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.cpp
@@ -60,6 +60,7 @@ struct LiveState
     // block; the callbacks post a command for the poll thread to send.
     std::atomic<uint64_t> frameNumber{0};
     std::atomic<bool>     paused{false};
+    std::atomic<uint32_t> serverVersion{0};   // protocol version last seen from server
     std::mutex            ctlMtx;    // guards pending / stepFrames
     Ctl                   pending = Ctl::None;
     int32_t               stepFrames = 0;
@@ -217,7 +218,7 @@ bool SendCommand(Conn& c, const char* verb, int32_t arg)
 // (converted to core-ready form). Also returns the run state via outPaused /
 // outFrame. Returns false on any protocol/socket error.
 bool ReadSnapshot(Conn& c, const char* verb, int32_t arg, LiveSnapshot& snap,
-                  bool& outPaused, uint64_t& outFrame)
+                  bool& outPaused, uint64_t& outFrame, uint32_t& outVersion)
 {
     if (!SendCommand(c, verb, arg))
     {
@@ -239,6 +240,7 @@ bool ReadSnapshot(Conn& c, const char* verb, int32_t arg, LiveSnapshot& snap,
         return false;
     }
     const uint32_t version = Rd32LE(head + 4);
+    outVersion = version;
     const int hasFb = (version >= 4u) ? 1 : 0;    // FB section added in v4
     const int numLen = 8 + hasFb;                 // section-length entries
     uint8_t lens[9 * 4];
@@ -332,7 +334,8 @@ void PollLoop(LiveState* st)
         LiveSnapshot snap;
         bool paused = false;
         uint64_t frame = 0;
-        if (!ReadSnapshot(conn, verb, arg, snap, paused, frame))
+        uint32_t sver = 0;
+        if (!ReadSnapshot(conn, verb, arg, snap, paused, frame, sver))
         {
             ConnClose(conn);   // will reconnect next iteration
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -344,6 +347,7 @@ void PollLoop(LiveState* st)
         }
         st->paused.store(paused);
         st->frameNumber.store(frame);
+        st->serverVersion.store(sver);
         std::this_thread::sleep_for(std::chrono::milliseconds(8));   // ~120 Hz cap
     }
     // Closing: if we left the emulator paused/stepped, release it before dropping
@@ -354,7 +358,8 @@ void PollLoop(LiveState* st)
         LiveSnapshot tmp;
         bool p = false;
         uint64_t fr = 0;
-        ReadSnapshot(conn, SE_LIVE_VERB_RESUME, 0, tmp, p, fr);   // best-effort
+        uint32_t sv = 0;
+        ReadSnapshot(conn, SE_LIVE_VERB_RESUME, 0, tmp, p, fr, sv);   // best-effort
     }
     ConnClose(conn);
 }
@@ -520,4 +525,14 @@ extern "C" se_result se_live_open(const char* endpoint, se_data_source* out)
     out->frame_number   = CbFrameNumber;
     out->close          = CbClose;
     return SE_OK;
+}
+
+extern "C" uint32_t se_live_server_version(const se_data_source* ds)
+{
+    // Only meaningful for a data source we produced (identified by our close cb).
+    if (!ds || !ds->user || ds->close != CbClose)
+    {
+        return 0;
+    }
+    return St(ds->user)->serverVersion.load();
 }

--- a/SaturnExplorer/Drivers/Live/src/LiveDriver.h
+++ b/SaturnExplorer/Drivers/Live/src/LiveDriver.h
@@ -18,6 +18,12 @@ extern "C" {
  * se_destroy). Returns SE_ERR_IO if the emulator isn't reachable. */
 se_result se_live_open(const char* endpoint, se_data_source* out);
 
+/* The live protocol version last reported by the connected server, or 0 if not
+ * connected / not a live source. Compare against SE_LIVE_VERSION to detect a
+ * client/emulator version mismatch. 'ds' must be an se_data_source filled by
+ * se_live_open. */
+uint32_t se_live_server_version(const se_data_source* ds);
+
 #ifdef __cplusplus
 }
 #endif

--- a/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
+++ b/SaturnExplorer/FrontEnd/Platforms/Windows/WinMain.cpp
@@ -4,16 +4,23 @@
 // the portable App class.
 #include <windows.h>
 
+#include <cstdio>    // snprintf
 #include <cstdlib>   // __argc / __argv
 #include <cstring>
 
 #include "WindowsPlatform.h"
 #include "App.h"
+#include "SeLiveProtocol.h"   // SE_LIVE_VERSION (live-tap protocol version)
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
 {
     sfe::WindowsPlatform platform;
     sfe::PlatformConfig config;
+    // Show the live-tap protocol version in the title so a client/emulator
+    // mismatch (which breaks live capture) is obvious at a glance.
+    char title[64];
+    std::snprintf(title, sizeof(title), "Saturn Explorer  \xE2\x80\x94  live proto v%u", SE_LIVE_VERSION);
+    config.mTitle = title;
     if (!platform.Initialize(config))
     {
         return 1;

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -14,7 +14,8 @@
 #include "Theme.h"
 #include "SavestateDriver.h"
 #ifdef SE_ENABLE_LIVE
-#include "LiveDriver.h"   // native builds only (threads/sockets)
+#include "LiveDriver.h"      // native builds only (threads/sockets)
+#include "SeLiveProtocol.h"  // SE_LIVE_VERSION (client protocol version)
 #endif
 
 namespace sfe
@@ -839,15 +840,43 @@ void App::DrawToolbar(IPlatform& platform)
         ImGui::Button("Help");
         ImGui::EndDisabled();
 
-        // Right-aligned live counters.
-        char info[96];
-        std::snprintf(info, sizeof(info), "FPS %.1f   |   VDP1: %zu objs   |   VDP2 regs: %s",
+        // Right-aligned live counters. When connected live, show the client vs
+        // server live-protocol version and flag a mismatch (which breaks capture).
+        char live[72] = "";
+        bool mismatch = false;
+#ifdef SE_ENABLE_LIVE
+        if (mbLiveSource)
+        {
+            const uint32_t sv = se_live_server_version(&mDataSource);
+            if (sv != 0 && sv != SE_LIVE_VERSION)
+            {
+                mismatch = true;
+                std::snprintf(live, sizeof(live),
+                              "   |   LIVE MISMATCH: client v%u / Yabause v%u",
+                              static_cast<unsigned>(SE_LIVE_VERSION), static_cast<unsigned>(sv));
+            }
+            else
+            {
+                std::snprintf(live, sizeof(live), "   |   live proto v%u",
+                              static_cast<unsigned>(SE_LIVE_VERSION));
+            }
+        }
+#endif
+        char info[160];
+        std::snprintf(info, sizeof(info), "FPS %.1f   |   VDP1: %zu objs   |   VDP2 regs: %s%s",
                       ImGui::GetIO().Framerate,
                       mbHasData ? se_sprite_count(mContext) : 0,
-                      mbHasData ? "loaded" : "-");
+                      mbHasData ? "loaded" : "-", live);
         const float w = ImGui::CalcTextSize(info).x;
         ImGui::SameLine(ImGui::GetWindowWidth() - w - 12.0f);
-        ImGui::TextUnformatted(info);
+        if (mismatch)
+        {
+            ImGui::TextColored(ImVec4(1.0f, 0.42f, 0.32f, 1.0f), "%s", info);
+        }
+        else
+        {
+            ImGui::TextUnformatted(info);
+        }
     }
     ImGui::End();
 }

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -11,6 +11,7 @@
 #include "se_export.h"
 #include "SeLiveProtocol.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -359,6 +360,10 @@ int SeExportInit(void)
      * local socket, which is the primary path for native clients. */
     sTcpThreadStarted = (pthread_create(&sTcpThread, NULL, SeTcpServerThread, NULL) == 0);
 #endif
+    /* Surface the protocol version so a client/emulator mismatch is diagnosable
+     * (Saturn Explorer must be built for the same SE_LIVE_VERSION to capture). */
+    fprintf(stderr, "[SaturnExplorer] live tap ready: protocol v%u\n",
+            (unsigned)SE_LIVE_VERSION);
     return 0;
 }
 


### PR DESCRIPTION
Makes live protocol version mismatches visible so "connected but no data" is diagnosable at a glance.

- The LiveDriver records the server's protocol version from each snapshot and exposes it via `se_live_server_version()`. Saturn Explorer's status bar shows `live proto vN` when connected, and turns into a red `LIVE MISMATCH: client vX / Yabause vY` when they differ (the exact case that breaks capture).
- The window title carries the client's live-tap protocol version.
- `se_export` prints its protocol version on init, so the Yabause side is visible in its console (its window title is port-specific and out of this module's reach).

**Verification:** `se_live_server_version` reports 3 vs 4 correctly against v3/v4 mock servers while frames + VDP1 FB stream. Desktop builds clean; web `App.cpp` compiles; `se_export.c` compiles as C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_