### PR TITLE
Yabause: capture VIDSoft's displayed VDP1 framebuffer, not the blank global

### DIFF
--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -125,9 +125,16 @@ counter) — the exact bytes Saturn Explorer's savestate loader already understa
 just set the state `SeExportGateFrame()` reads. Wire format (protocol v4):
 `Drivers/Common/src/SeLiveProtocol.h`.
 
-The VDP1 frame buffer comes from the `Vdp1FrameBuffer[0]` argument to
-`SeExportSnapshot` (the hook `apply.py` inserts). If your Yabause fork names or
-banks that buffer differently, adjust that one argument.
+**VDP1 frame buffer source.** The *global* `Vdp1FrameBuffer` in Yabause is only a
+fallback — during play every real frame-buffer access is routed through the active
+video core, so the global stays blank. VIDSoft keeps the pixels in its own
+`vdp1frontframebuffer` / `vdp1backframebuffer` (two 256 KiB RGB555 banks that swap
+each frame). `apply.py` therefore adds a small `VIDSoftGetVdp1FrameBuffer()`
+accessor to `vidsoft.c` (returning the displayed *front* bank) and passes that to
+`SeExportSnapshot`, grabbed at `Vdp2VBlankOUT` (post-swap, so no mid-draw tearing).
+Caveat: this is the **software** renderer. VIDOGL keeps the frame buffer on the GPU
+and would need a read-back — if you run the OpenGL core, the FB section will be
+empty until that's added.
 
 ## Web (browser) live viewing
 The browser can't open a local socket, so the web build reaches Yabause over a

--- a/SaturnExplorer/Integration/Yabause/apply.py
+++ b/SaturnExplorer/Integration/Yabause/apply.py
@@ -85,9 +85,22 @@ EDITS = [
     ("vdp2.c",
      r'(void Vdp2VBlankOUT\(void\)\s*\{[\s\S]*?static VideoInterface_struct \* saved = NULL;\s*\n)',
      "after_group1",
+     "   /* Pass VIDSoft's displayed VDP1 frame buffer (front bank). The global\n"
+     "    * Vdp1FrameBuffer is only a fallback and stays blank during play; real\n"
+     "    * pixels live in the active video core (see VIDSoftGetVdp1FrameBuffer). */\n"
+     "   extern u8 *VIDSoftGetVdp1FrameBuffer(void);\n"
      "   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,\n"
-     "                    Vdp1Regs, LowWram, HighWram, Vdp1FrameBuffer[0]);\n",
+     "                    Vdp1Regs, LowWram, HighWram, VIDSoftGetVdp1FrameBuffer());\n",
      "SeExportSnapshot("),
+
+    # --- vidsoft.c: expose the displayed VDP1 frame buffer (it's file-static). ---
+    ("vidsoft.c",
+     r'(VideoInterface_struct VIDSoft\s*=\s*\{)',
+     "before_group1",
+     "/* Displayed VDP1 frame buffer (front bank) for the Saturn Explorer live tap.\n"
+     "   vidsoft's real pixels live here, not in the global Vdp1FrameBuffer. */\n"
+     "u8 *VIDSoftGetVdp1FrameBuffer(void) { return vdp1frontframebuffer; }\n",
+     "VIDSoftGetVdp1FrameBuffer"),
 ]
 
 # A fenced SE_EXPORT block (for update-in-place when a hook's content changes).
@@ -117,6 +130,9 @@ def apply_edit(text, anchor, mode, code):
     if mode == "before_group2":
         # keep group1 (a newline), insert before group2
         ins = m.start(2)
+        return text[:ins] + block + text[ins:], True, True
+    if mode == "before_group1":
+        ins = m.start(1)
         return text[:ins] + block + text[ins:], True, True
     if mode == "after_group1":
         ins = m.end(1)
@@ -192,7 +208,7 @@ def copy_sources(src_dir, do_write):
 
 def revert(src_dir):
     fence_re = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END) + r"\n?", re.DOTALL)
-    for fname in ("yabause.c", "vdp2.c"):
+    for fname in ("yabause.c", "vdp2.c", "vidsoft.c"):
         path = os.path.join(src_dir, fname)
         if os.path.isfile(path):
             t = open(path, encoding="utf-8", errors="surrogateescape").read()
@@ -231,7 +247,7 @@ def main():
     notes = []
     if do_write:
         notes += copy_sources(src_dir, do_write)
-    for fname in ("yabause.c", "vdp2.c"):
+    for fname in ("yabause.c", "vdp2.c", "vidsoft.c"):
         notes.append(fname + ":")
         notes += process_file(src_dir, fname, do_write)
     notes.append("CMakeLists.txt:")

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -28,12 +28,15 @@ int SeExportInit(void);
 /* Copy the current Saturn memory into the export double-buffer. Call once per
  * frame, e.g. at the end of Vdp2VBlankOUT(), passing Yabause's globals:
  *   SeExportSnapshot(Vdp1Ram, Vdp2Ram, Vdp2ColorRam, Vdp2Regs,
- *                    Vdp1Regs, LowWram, HighWram, Vdp1FrameBuffer[0]);
+ *                    Vdp1Regs, LowWram, HighWram, VIDSoftGetVdp1FrameBuffer());
  * Sizes are fixed by the hardware. 'vdp1_regs_struct' is Yabause's `Vdp1` struct
  * (its first 11 u16 fields TVMR..MODR); this module builds the hardware-offset
- * register image from it. 'vdp1_fb_256k' is the VDP1 frame buffer (drawn output;
- * Yabause exposes it as Vdp1FrameBuffer[0] — adjust for your fork if it differs).
- * Any argument may be NULL (that section is zeros). */
+ * register image from it. 'vdp1_fb_256k' is the VDP1 frame buffer (drawn output,
+ * 256 KiB RGB555). Note: the *global* `Vdp1FrameBuffer` is only a fallback in
+ * Yabause — real pixels live in the active video core, so apply.py adds a tiny
+ * VIDSoftGetVdp1FrameBuffer() accessor returning VIDSoft's displayed front bank.
+ * (VIDOGL keeps pixels on the GPU and would need a read-back instead.) Any
+ * argument may be NULL (that section is zeros). */
 void SeExportSnapshot(const void* vdp1_vram_512k, const void* vdp2_vram_512k,
                       const void* cram_4k, const void* vdp2_regs_struct_288,
                       const void* vdp1_regs_struct, const void* wram_low_1m,


### PR DESCRIPTION
The exported VDP1 framebuffer section was all zeros. The global `Vdp1FrameBuffer` is only a fallback in Yabause — during play every real frame-buffer access routes through the active video core, so the global never gets populated.

**Fix:** `apply.py` now adds a tiny `VIDSoftGetVdp1FrameBuffer()` accessor to `vidsoft.c` (returning the displayed front bank `vdp1frontframebuffer`, 256 KiB RGB555) and passes that to `SeExportSnapshot` instead of `Vdp1FrameBuffer[0]`. It's grabbed at `Vdp2VBlankOUT` (post buffer-swap) so there's no mid-draw tearing.

- New `before_group1` insert mode; the accessor lands just before the `VIDSoft` interface struct (after `vdp1frontframebuffer` is declared) and is covered by `--check`/`--revert` and update-in-place like every other hook.
- `se_export.h` + README document the fallback-vs-core distinction and that VIDOGL keeps the FB on the GPU (would need a read-back).

**Verification:** on a fake tree, apply.py inserts the accessor + wires the hook, is idempotent, and updates an old `Vdp1FrameBuffer[0]` hook to the accessor in place; apply.py parses; `se_export.c` compiles as C.

Credit to the repo owner for catching that the global buffer was the fallback, not the live one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_