### PR TITLE
Yabause: forward-declare vdp1frontframebuffer in the injected VDP1 FB accessor

### DIFF
--- a/SaturnExplorer/Integration/Yabause/apply.py
+++ b/SaturnExplorer/Integration/Yabause/apply.py
@@ -98,7 +98,10 @@ EDITS = [
      r'(VideoInterface_struct VIDSoft\s*=\s*\{)',
      "before_group1",
      "/* Displayed VDP1 frame buffer (front bank) for the Saturn Explorer live tap.\n"
-     "   vidsoft's real pixels live here, not in the global Vdp1FrameBuffer. */\n"
+     "   vidsoft's real pixels live here, not in the global Vdp1FrameBuffer.\n"
+     "   Forward-declare the file-static buffer so this accessor compiles no matter\n"
+     "   where the block lands (it's defined further down in vidsoft.c). */\n"
+     "extern u8 *vdp1frontframebuffer;\n"
      "u8 *VIDSoftGetVdp1FrameBuffer(void) { return vdp1frontframebuffer; }\n",
      "VIDSoftGetVdp1FrameBuffer"),
 ]


### PR DESCRIPTION
Fixes a compile break in the `apply.py` `vidsoft.c` hook (caught in review).

The hook inserts `VIDSoftGetVdp1FrameBuffer()` **before** the `VideoInterface_struct VIDSoft = {` definition, but `vdp1frontframebuffer` is a file-static declared further down in `vidsoft.c` — so the injected accessor referenced an undeclared identifier and the patched Yabause tree wouldn't compile on a fresh apply.

**Fix:** prepend a forward declaration to the injected snippet so the accessor is valid no matter where the block lands:

```c
extern u8 *vdp1frontframebuffer;
u8 *VIDSoftGetVdp1FrameBuffer(void) { return vdp1frontframebuffer; }
```

`apply.py` updates the fenced `SE_EXPORT` block in place, so re-running it on an already-patched tree swaps in the corrected snippet idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_