### PR TITLE
Core: don't let a collapsed (zero-area) sprite swallow every click

### DIFF
--- a/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
+++ b/SaturnExplorer/Core/src/Vdp1Rasterizer.cpp
@@ -335,6 +335,17 @@ bool PointInSprite(const se_sprite_2d& sprite, float px, float py)
 
     auto inTriangle = [&](const se_vec2& p0, const se_vec2& p1, const se_vec2& p2)
     {
+        // Reject a degenerate (zero-area) triangle. Its three edge functions are
+        // all 0 for every point, so the sign test below would report EVERY point
+        // as "inside" — letting a sprite whose screen quad has collapsed to a line
+        // or point (off-screen/scaled-to-nothing, but still in the list) swallow
+        // every click and shadow the real sprite underneath. An invisible sprite
+        // must not be clickable.
+        const float area = Edge(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y);
+        if (area > -1e-3f && area < 1e-3f)
+        {
+            return false;
+        }
         const float e0 = Edge(p0.x, p0.y, p1.x, p1.y, px, py);
         const float e1 = Edge(p1.x, p1.y, p2.x, p2.y, px, py);
         const float e2 = Edge(p2.x, p2.y, p0.x, p0.y, px, py);


### PR DESCRIPTION
Fixes the reported "clicking a sprite selects nothing" bug (Panzer Dragoon scene, `MK81307`).

**Root cause.** `PointInSprite` splits the quad into triangles and uses the standard edge-function sign test, which treats *all-zero* edge functions as "inside" (a point lying on the boundary). When a sprite's screen quad collapses to a line or point — off-screen, or scaled to nothing, but still present in the sprite list — every edge function is `0` for **every** point, so that degenerate sprite reports itself as covering the whole screen. Being high in draw order, it wins the topmost hit test, so clicks anywhere resolved to an **invisible zero-area sprite** and no selection box ever appeared.

The diagnostic on the reported scene showed the stack at a wall pixel as `cmd 97 (area 0)` on top of the real wall sprites `cmd 25`/`cmd 6` — the area-0 sprite was intercepting the click.

**Fix.** Reject a degenerate (`|area| ≈ 0`) triangle before the sign test, so a collapsed, invisible sprite is simply not clickable and the real sprite under the cursor is selected. Only sub-pixel-area quads are affected; visible sprites are unchanged, and rendering is untouched (this is hit-test only).

**Verification.** Reproduced the exact bug on the `MK81307` savestate, then confirmed after the fix: the five sampled wall points now return real sprites (25/27/59/161/33) instead of the phantom `97`; every large terrain sprite's own centroid now selects itself; whole-frame hit coverage is otherwise unchanged and no visible sprite lost selectability. Desktop links; web/no-live config compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_