### PR TITLE
Frontend: decode the VDP1 frame buffer as host-endian by default

### DIFF
--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -1235,7 +1235,9 @@ constexpr uint8_t kPrioHeat[8][3] = {
 //  - Raw RGB555: every word shown as RGB555 (exact for RGB sprites; colour-bank
 //    pixels look wrong — useful to inspect the raw bits).
 //  - Priority: per-pixel priority (SPCTL type -> PRISA..PRISD) as a heatmap.
-// Word 0 (erased) is transparent. "Byte-swap" flips word endianness if needed.
+// Word 0 (erased) is transparent. The frame buffer is host-endian (software
+// renderer writes native u16, so little-endian by default); "Byte-swap" flips to
+// big-endian for a big-endian source.
 void App::DrawVdp1Framebuffer(IPlatform& platform)
 {
     constexpr int kFbW = 512;
@@ -1279,6 +1281,11 @@ void App::DrawVdp1Framebuffer(IPlatform& platform)
         ImGui::Combo("##fbmode", &mFbMode, kModes, IM_ARRAYSIZE(kModes));
         ImGui::SameLine();
         ImGui::Checkbox("Byte-swap", &mFbByteSwap);
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("Frame buffer is host-endian (little-endian) by default.\n"
+                              "Enable only if colours look wrong (big-endian source).");
+        }
         ImGui::SameLine();
         if (haveVdp2)
             ImGui::TextDisabled("type %X  %s  512x256", sprType, spclmd ? "mixed" : "palette");
@@ -1291,10 +1298,15 @@ void App::DrawVdp1Framebuffer(IPlatform& platform)
 
         auto wordAt = [&](int i) -> uint16_t
         {
+            // The VDP1 frame buffer is host-endian: the software renderer (VIDSoft)
+            // writes native u16 pixels, so on the usual little-endian host the low
+            // byte comes first — unlike VDP1/VDP2 VRAM, which is big-endian. Default
+            // to little-endian (correct for real captures); "Byte-swap" flips to
+            // big-endian for a big-endian source.
             const uint8_t b0 = mFbRaw[i * 2], b1 = mFbRaw[i * 2 + 1];
             return mFbByteSwap
-                ? static_cast<uint16_t>((static_cast<uint16_t>(b1) << 8) | b0)
-                : static_cast<uint16_t>((static_cast<uint16_t>(b0) << 8) | b1);
+                ? static_cast<uint16_t>((static_cast<uint16_t>(b0) << 8) | b1)
+                : static_cast<uint16_t>((static_cast<uint16_t>(b1) << 8) | b0);
         };
 
         // Decode a word to RGBA per the active mode. A == 0 means transparent.

--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -121,7 +121,10 @@ little-endian argument). Every command replies with a full snapshot: VDP1 VRAM
 the VDP1 register image, low + high work RAM (1 MiB each), the VDP1 frame buffer
 (256 KiB, the drawn output), and a small control block (paused flag + frame
 counter) — the exact bytes Saturn Explorer's savestate loader already understands
-(VRAM big-endian, CRAM host-endian, VDP2 the raw struct). The pause/step verbs
+(VRAM big-endian, CRAM host-endian, VDP2 the raw struct). The VDP1 frame buffer is
+**host-endian** like CRAM: VIDSoft writes native `u16` pixels, so on a little-endian
+host the bytes are little-endian (the FB viewer decodes little-endian by default).
+The pause/step verbs
 just set the state `SeExportGateFrame()` reads. Wire format (protocol v4):
 `Drivers/Common/src/SeLiveProtocol.h`.
 


### PR DESCRIPTION
The VDP1 Framebuffer viewer showed byte-swapped colours on real captures (Panzer Dragoon), which the **Byte-swap** toggle worked around. This makes the default correct.

**Why:** the VDP1 frame buffer is **host-endian**, not big-endian. VIDSoft's software renderer writes native `u16` pixels straight into `vdp1frontframebuffer`, so on the usual little-endian host the low byte comes first — unlike VDP1/VDP2 VRAM, which Yabause stores big-endian. The panel assumed big-endian (matching VRAM) and read the two bytes swapped.

**Fix:** default the FB word read to little-endian (host order), which is correct for real captures; the **Byte-swap** checkbox now flips to big-endian for a big-endian source and has a tooltip explaining it. Also documents the FB endianness in the Yabause integration README (it's host-endian, like CRAM).

No functional change beyond the default endianness; desktop links, web/no-live config compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_