### PR TITLE
Debugger Phase 1: Watch Window + memory backend interface

### DIFF
--- a/SaturnExplorer/.gitignore
+++ b/SaturnExplorer/.gitignore
@@ -16,6 +16,9 @@ CTestTestfile.cmake
 x64/
 Win32/
 Libs/
+# ...but the debugger backend source lives here and must be tracked.
+!FrontEnd/src/Debug/
+!FrontEnd/src/Debug/**
 
 # Stray render / test output (harnesses write PNGs; none are tracked here)
 *.png

--- a/SaturnExplorer/CMakeLists.txt
+++ b/SaturnExplorer/CMakeLists.txt
@@ -108,6 +108,9 @@ if(WIN32)
     add_executable(SaturnExplorerFrontEnd WIN32
         FrontEnd/src/App.cpp
         FrontEnd/src/Theme.cpp
+        FrontEnd/src/WatchPanel.cpp
+        FrontEnd/src/Debug/WatchList.cpp
+        FrontEnd/src/Debug/MemoryBackend.cpp
         FrontEnd/src/FrameRecorder.cpp
         FrontEnd/src/FrameLz.cpp
         FrontEnd/Platforms/Windows/WindowsPlatform.cpp
@@ -145,6 +148,9 @@ elseif(EMSCRIPTEN)
     add_executable(SaturnExplorerFrontEnd
         FrontEnd/src/App.cpp
         FrontEnd/src/Theme.cpp
+        FrontEnd/src/WatchPanel.cpp
+        FrontEnd/src/Debug/WatchList.cpp
+        FrontEnd/src/Debug/MemoryBackend.cpp
         FrontEnd/Platforms/Web/WebPlatform.cpp
         FrontEnd/Platforms/Web/WebMain.cpp
         ${SE_IMGUI_CORE}
@@ -184,6 +190,9 @@ else()
         add_executable(SaturnExplorerFrontEnd
             FrontEnd/src/App.cpp
             FrontEnd/src/Theme.cpp
+            FrontEnd/src/WatchPanel.cpp
+            FrontEnd/src/Debug/WatchList.cpp
+            FrontEnd/src/Debug/MemoryBackend.cpp
             FrontEnd/src/FrameRecorder.cpp
             FrontEnd/src/FrameLz.cpp
             FrontEnd/Platforms/Web/WebPlatform.cpp

--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -208,10 +208,12 @@ void App::Initialize()
 #ifdef SE_ENABLE_LIVE
     mRecorder.Configure(mRecordSeconds * kFramesPerSecond);
 #endif
+    mWatchPanel.LoadSession();   // restore the session's watch list, if any
 }
 
 void App::Shutdown()
 {
+    mWatchPanel.SaveSession();
     CloseData();
 }
 
@@ -655,10 +657,12 @@ void App::BuildUI(IPlatform& platform)
     DrawPaletteViewer();
     DrawReferences();
 
-    // Right column.
+    // Right column. (The old Texture Preview / Palette (CLUT) panels duplicated the
+    // center Texture/Palette viewers; the debugger Watch + Assembly panels live here
+    // now.)
     DrawSelectedObject();
-    DrawPlaceholder("Texture Preview", "Preview of the selected sprite's texture — see the Texture Viewer panel.");
-    DrawPlaceholder("Palette (CLUT)", "Palette of the selected sprite — see the Palette Viewer panel.");
+    DrawWatch(platform);
+    DrawAssembly();
     DrawPlaceholder("Memory History", "Load chain (File → CD → DMA → Write) — arrives in M7.");
     // contextSwap restores the live context here as it goes out of scope.
 }
@@ -694,11 +698,12 @@ void App::BuildDefaultLayout(unsigned int dockspaceId)
     const ImGuiID cbPal = ImGui::DockBuilderSplitNode(bottomRest, ImGuiDir_Left, 0.50f, nullptr, &bottomRest);
     const ImGuiID cbRefs = bottomRest;
 
-    // Right inspector column, top to bottom.
+    // Right inspector column, top to bottom. Watch (rTex) + SH-2 Assembly (rPal)
+    // are the debugger focus, so they get the bulk of the height.
     ImGuiID rightRest = right;
-    const ImGuiID rObj  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.45f, nullptr, &rightRest);
-    const ImGuiID rTex  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.25f, nullptr, &rightRest);
-    const ImGuiID rPal  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.40f, nullptr, &rightRest);
+    const ImGuiID rObj  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.22f, nullptr, &rightRest);
+    const ImGuiID rTex  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.42f, nullptr, &rightRest);
+    const ImGuiID rPal  = ImGui::DockBuilderSplitNode(rightRest, ImGuiDir_Up, 0.62f, nullptr, &rightRest);
     const ImGuiID rMem  = rightRest;
 
     ImGui::DockBuilderDockWindow("Layer Controls", leftTop);
@@ -722,8 +727,8 @@ void App::BuildDefaultLayout(unsigned int dockspaceId)
     ImGui::DockBuilderDockWindow("References", cbRefs);
 
     ImGui::DockBuilderDockWindow("Selected Object", rObj);
-    ImGui::DockBuilderDockWindow("Texture Preview", rTex);
-    ImGui::DockBuilderDockWindow("Palette (CLUT)", rPal);
+    ImGui::DockBuilderDockWindow("Watch", rTex);
+    ImGui::DockBuilderDockWindow("SH-2 Assembly", rPal);
     ImGui::DockBuilderDockWindow("Memory History", rMem);
 
     ImGui::DockBuilderFinish(dockspaceId);
@@ -1082,6 +1087,34 @@ void App::DrawLayerControls()
         CheckboxU8("Window", &mRenderOpts.show_window);
         CheckboxU8("Color Calculation", &mRenderOpts.show_color_calculation);
         CheckboxU8("Shadow / Highlight", &mRenderOpts.show_shadow_highlight);
+    }
+    ImGui::End();
+}
+
+// Debugger Watch Window — the panel owns its list/refresh; App just supplies the
+// memory backend (served from the current context) and the expression resolver.
+void App::DrawWatch(IPlatform& platform)
+{
+    mWatchPanel.Draw(mMemBackend, mExprResolver, platform, ImGui::GetIO().DeltaTime);
+}
+
+// SH-2 Assembly — placeholder until the emulator exports CPU state. The panel and
+// its docking slot exist now so the layout is final; the disassembler + live PC
+// arrive in later phases (needs SH-2 register/PC + breakpoint export from Yabause).
+void App::DrawAssembly()
+{
+    if (ImGui::Begin("SH-2 Assembly"))
+    {
+        ImGui::TextUnformatted("SH-2 disassembly");
+        ImGui::Separator();
+        ImGui::TextWrapped(
+            "Live instruction view around the master/slave PC, breakpoints, and "
+            "stepping arrive in a later phase. They need the emulator to export "
+            "SH-2 registers/PC and breakpoint hooks (a protocol update + Yabause "
+            "rebuild), plus the SH-2 disassembler.");
+        ImGui::Spacing();
+        ImGui::TextDisabled("Planned: CPU selector (Master/Slave), Follow PC, branch "
+                            "navigation, gutter breakpoints, Run to Here.");
     }
     ImGui::End();
 }

--- a/SaturnExplorer/FrontEnd/src/App.h
+++ b/SaturnExplorer/FrontEnd/src/App.h
@@ -11,6 +11,9 @@
 #include "saturnexplorer/SaturnExplorer.h"
 
 #include "Platform/IPlatform.h"
+#include "WatchPanel.h"          // Watch Window (debugger; emulator-agnostic)
+#include "Debug/MemoryBackend.h"
+#include "Debug/WatchList.h"
 
 #ifdef SE_ENABLE_LIVE
 #include "FrameRecorder.h"   // rolling capture of live frames (native only)
@@ -60,6 +63,8 @@ private:
     void DrawStatusBar();
     void DrawLayerControls();
     void DrawVdpOutput(IPlatform& platform);
+    void DrawWatch(IPlatform& platform);   // debugger Watch Window
+    void DrawAssembly();                    // SH-2 Assembly (placeholder in this phase)
     void DrawVdp1Framebuffer(IPlatform& platform);
     void DrawWorldView(IPlatform& platform);
     void DrawCommandList();
@@ -91,6 +96,12 @@ private:
     se_data_source mDataSource {};
     se_context*    mContext = nullptr;
     bool           mbHasData = false;
+
+    // Debugger panels (emulator-agnostic: they read through the backend interface,
+    // which is served here from the current se_context — live snapshot or scrub).
+    ContextBackend           mMemBackend{&mContext};
+    SimpleExpressionResolver mExprResolver;
+    WatchPanel               mWatchPanel;
 
     se_render_opts   mRenderOpts {};
     bool             mbLiveSource = false;    // data comes from a running emulator

--- a/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.cpp
@@ -1,0 +1,112 @@
+#include "Debug/MemoryBackend.h"
+
+#include <cstring>
+
+namespace sfe
+{
+
+namespace
+{
+// Saturn CPU memory map (the regions the snapshot captures). Addresses are
+// normalized to their canonical mirror first (the SH-2 sees WRAM/VDP at several
+// cache/through mirrors that share the low 27 bits).
+struct Region
+{
+    uint32_t     base;
+    uint32_t     size;
+    se_vram_kind kind;
+};
+constexpr Region kRegions[] = {
+    { 0x00200000u, 0x00100000u, SE_VRAM_KIND_WRAM_LOW  },  // Low work RAM (1 MiB)
+    { 0x06000000u, 0x00100000u, SE_VRAM_KIND_WRAM_HIGH },  // High work RAM (1 MiB)
+    { 0x05C00000u, 0x00080000u, SE_VRAM_KIND_VDP1_VRAM },  // VDP1 VRAM (512 KiB)
+    { 0x05E00000u, 0x00080000u, SE_VRAM_KIND_VDP2_VRAM },  // VDP2 VRAM (512 KiB)
+    { 0x05F00000u, 0x00001000u, SE_VRAM_KIND_CRAM      },  // Color RAM (4 KiB)
+};
+
+// VDP register windows, served through the register getters (not se_read_vram).
+constexpr uint32_t kVdp1RegBase = 0x05D00000u, kVdp1RegSize = 0x18u;
+constexpr uint32_t kVdp2RegBase = 0x05F80000u, kVdp2RegSize = 0x120u;
+
+uint32_t Canonical(uint32_t addr)
+{
+    return addr & 0x07FFFFFFu;   // fold cache/through mirrors onto the low 27 bits
+}
+}  // namespace
+
+MemoryReadResult ContextBackend::ReadOne(uint32_t address, uint32_t size) const
+{
+    MemoryReadResult r;
+    if (!Connected())
+    {
+        r.error = "Disconnected";
+        return r;
+    }
+    if (size == 0 || size > 4)
+    {
+        r.error = "Bad size";
+        return r;
+    }
+    se_context* ctx = *mContext;
+    const uint32_t a = Canonical(address);
+
+    // VDP registers: assemble big-endian bytes from 16-bit register reads.
+    auto readRegs = [&](uint32_t base, uint32_t regSize, bool vdp1) -> bool
+    {
+        if (a < base || a + size > base + regSize)
+        {
+            return false;
+        }
+        r.bytes.resize(size);
+        for (uint32_t i = 0; i < size; ++i)
+        {
+            const uint32_t off = (a - base) + i;
+            const uint16_t reg = vdp1 ? se_get_vdp1_register(ctx, off & ~1u)
+                                      : se_get_vdp2_register(ctx, off & ~1u);
+            r.bytes[i] = (off & 1u) ? static_cast<uint8_t>(reg & 0xFF)
+                                    : static_cast<uint8_t>(reg >> 8);   // big-endian
+        }
+        r.success = true;
+        return true;
+    };
+    if (readRegs(kVdp1RegBase, kVdp1RegSize, true))  return r;
+    if (readRegs(kVdp2RegBase, kVdp2RegSize, false)) return r;
+
+    // RAM/VRAM/CRAM regions via the raw byte reader.
+    for (const Region& reg : kRegions)
+    {
+        if (a < reg.base || a + size > reg.base + reg.size)
+        {
+            continue;
+        }
+        r.bytes.resize(size);
+        const size_t got = se_read_vram(ctx, reg.kind, a - reg.base, r.bytes.data(), size);
+        if (got == size)
+        {
+            r.success = true;
+        }
+        else
+        {
+            r.bytes.clear();
+            r.error = "Unavailable";
+        }
+        return r;
+    }
+
+    r.error = "Unmapped address";
+    return r;
+}
+
+std::vector<MemoryReadResult> ContextBackend::ReadMemoryBatch(
+    const std::vector<MemoryReadRequest>& requests)
+{
+    std::vector<MemoryReadResult> out;
+    out.reserve(requests.size());
+    for (const MemoryReadRequest& req : requests)
+    {
+        out.push_back(ReadOne(req.address, req.size));
+    }
+    return out;
+}
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.h
+++ b/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.h
@@ -1,0 +1,68 @@
+// MemoryBackend — the debugger's view of emulator memory, isolated from any
+// specific emulator. Panels (Watch, later Assembly/Hex) depend only on this
+// interface; the concrete backend reads from an se_context (which the live driver
+// or a savestate fills), so no Yabause-specific code reaches the UI widgets.
+//
+// Reads are expressed as a batch so a future remote/async backend can coalesce
+// them; the current ContextBackend serves them synchronously from the already
+// captured snapshot (a fast local copy — it never blocks on I/O).
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "saturnexplorer/SaturnExplorer.h"
+
+namespace sfe
+{
+
+struct MemoryReadRequest
+{
+    uint32_t address = 0;
+    uint32_t size = 0;
+};
+
+struct MemoryReadResult
+{
+    bool                 success = false;
+    std::vector<uint8_t> bytes;      // big-endian Saturn bytes, 'size' long on success
+    std::string          error;      // human-readable reason when !success
+};
+
+class IMemoryBackend
+{
+public:
+    virtual ~IMemoryBackend() = default;
+
+    // True when a source is loaded and reads can succeed. Panels show a
+    // "disconnected" state otherwise instead of spamming errors.
+    virtual bool Connected() const = 0;
+
+    // Read each request; results are parallel to 'requests'. Never throws; a
+    // failed read yields {success=false, error=...}. Bytes are raw Saturn memory
+    // (big-endian) so callers interpret multi-byte values big-endian.
+    virtual std::vector<MemoryReadResult> ReadMemoryBatch(
+        const std::vector<MemoryReadRequest>& requests) = 0;
+};
+
+// Backend over an se_context. Holds a pointer-to-pointer so it always follows the
+// app's current context (live snapshot, or a paused scrub frame) without re-wiring.
+class ContextBackend : public IMemoryBackend
+{
+public:
+    explicit ContextBackend(se_context** contextSlot) : mContext(contextSlot) {}
+
+    bool Connected() const override { return mContext && *mContext; }
+    std::vector<MemoryReadResult> ReadMemoryBatch(
+        const std::vector<MemoryReadRequest>& requests) override;
+
+    // Map a CPU-visible Saturn address (mirror bits normalized) to a captured
+    // region and read 'size' bytes. Public so hover/operand previews can reuse it.
+    MemoryReadResult ReadOne(uint32_t address, uint32_t size) const;
+
+private:
+    se_context** mContext = nullptr;
+};
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
@@ -1,0 +1,466 @@
+#include "Debug/WatchList.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
+#include "SaturnRegions.h"
+
+namespace sfe
+{
+
+const WatchType kAllWatchTypes[8] = {
+    WatchType::U8, WatchType::S8, WatchType::U16, WatchType::S16,
+    WatchType::U32, WatchType::S32, WatchType::RGB555, WatchType::Pointer };
+
+const char* WatchTypeName(WatchType t)
+{
+    switch (t)
+    {
+    case WatchType::U8:      return "U8";
+    case WatchType::S8:      return "S8";
+    case WatchType::U16:     return "U16";
+    case WatchType::S16:     return "S16";
+    case WatchType::U32:     return "U32";
+    case WatchType::S32:     return "S32";
+    case WatchType::RGB555:  return "RGB555";
+    case WatchType::Pointer: return "Pointer";
+    }
+    return "U16";
+}
+
+uint32_t WatchTypeSize(WatchType t)
+{
+    switch (t)
+    {
+    case WatchType::U8:  case WatchType::S8:                      return 1;
+    case WatchType::U16: case WatchType::S16: case WatchType::RGB555: return 2;
+    default:                                                     return 4;
+    }
+}
+
+bool WatchTypeFromName(const char* s, WatchType& out)
+{
+    for (WatchType t : kAllWatchTypes)
+    {
+        if (std::strcmp(s, WatchTypeName(t)) == 0) { out = t; return true; }
+    }
+    return false;
+}
+
+namespace
+{
+// Trim ASCII whitespace from both ends.
+std::string Trim(const std::string& s)
+{
+    size_t a = 0, b = s.size();
+    while (a < b && std::isspace((unsigned char)s[a])) ++a;
+    while (b > a && std::isspace((unsigned char)s[b - 1])) --b;
+    return s.substr(a, b - a);
+}
+
+// Parse a hex ("0x..." or bare hex) or decimal token. Returns false if not a
+// clean integer. 'allowBareHex' treats a bare token as hex (addresses) vs decimal.
+bool ParseInt(const std::string& tokIn, bool allowBareHex, uint32_t& out)
+{
+    std::string tok = Trim(tokIn);
+    if (tok.empty()) return false;
+    int base = 10;
+    size_t i = 0;
+    if (tok.size() > 2 && tok[0] == '0' && (tok[1] == 'x' || tok[1] == 'X'))
+    {
+        base = 16; i = 2;
+    }
+    else if (allowBareHex)
+    {
+        base = 16;
+    }
+    if (i >= tok.size()) return false;
+    uint32_t v = 0;
+    for (; i < tok.size(); ++i)
+    {
+        const char c = tok[i];
+        int d;
+        if (c >= '0' && c <= '9')      d = c - '0';
+        else if (c >= 'a' && c <= 'f') d = 10 + c - 'a';
+        else if (c >= 'A' && c <= 'F') d = 10 + c - 'A';
+        else return false;
+        if (d >= base) return false;
+        v = v * base + static_cast<uint32_t>(d);
+    }
+    out = v;
+    return true;
+}
+}  // namespace
+
+bool SimpleExpressionResolver::Resolve(const std::string& exprIn, uint32_t& outAddr,
+                                       std::string& outError)
+{
+    const std::string expr = Trim(exprIn);
+    if (expr.empty()) { outError = "Empty expression"; return false; }
+
+    // Split on the first top-level + or - (after the base token).
+    size_t op = std::string::npos;
+    for (size_t i = 1; i < expr.size(); ++i)
+    {
+        if (expr[i] == '+' || expr[i] == '-') { op = i; break; }
+    }
+    const std::string baseTok = (op == std::string::npos) ? expr : expr.substr(0, op);
+    uint32_t base = 0;
+    if (!ParseInt(baseTok, /*allowBareHex=*/true, base))
+    {
+        outError = "Invalid address";
+        return false;
+    }
+    if (op == std::string::npos)
+    {
+        outAddr = base;
+        return true;
+    }
+    const char sign = expr[op];
+    uint32_t off = 0;
+    if (!ParseInt(expr.substr(op + 1), /*allowBareHex=*/false, off))
+    {
+        outError = "Invalid offset";
+        return false;
+    }
+    outAddr = (sign == '+') ? (base + off) : (base - off);
+    return true;
+}
+
+std::string NormalizeExpression(const std::string& exprIn)
+{
+    const std::string expr = Trim(exprIn);
+    // Only normalize a pure address (no +/-); leave arithmetic expressions as typed.
+    for (size_t i = 1; i < expr.size(); ++i)
+    {
+        if (expr[i] == '+' || expr[i] == '-') return expr;
+    }
+    uint32_t v = 0;
+    if (ParseInt(expr, true, v))
+    {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "0x%08X", v);
+        return buf;
+    }
+    return expr;
+}
+
+bool IsPlausibleSaturnAddress(uint32_t addr)
+{
+    const uint32_t a = addr & 0x07FFFFFFu;
+    struct R { uint32_t lo, hi; };
+    static const R kOk[] = {
+        { 0x00000000u, 0x0007FFFFu },  // BIOS
+        { 0x00200000u, 0x002FFFFFu },  // Low work RAM
+        { 0x05C00000u, 0x05C7FFFFu },  // VDP1 VRAM
+        { 0x05D00000u, 0x05D0FFFFu },  // VDP1 regs
+        { 0x05E00000u, 0x05E7FFFFu },  // VDP2 VRAM
+        { 0x05F00000u, 0x05F00FFFu },  // CRAM
+        { 0x05F80000u, 0x05F8FFFFu },  // VDP2 regs
+        { 0x06000000u, 0x060FFFFFu },  // High work RAM
+    };
+    for (const R& r : kOk)
+    {
+        if (a >= r.lo && a <= r.hi) return true;
+    }
+    return false;
+}
+
+WatchValue FormatWatchValue(WatchType type, const MemoryReadResult& mem)
+{
+    WatchValue v;
+    if (!mem.success)
+    {
+        v.text = mem.error.empty() ? "Unavailable" : mem.error;
+        return v;
+    }
+    const uint32_t size = WatchTypeSize(type);
+    if (mem.bytes.size() < size)
+    {
+        v.text = "Unavailable";
+        return v;
+    }
+    // Big-endian assembly.
+    uint32_t raw = 0;
+    for (uint32_t i = 0; i < size; ++i) raw = (raw << 8) | mem.bytes[i];
+
+    char buf[48];
+    v.valid = true;
+    switch (type)
+    {
+    case WatchType::U8:
+        std::snprintf(buf, sizeof(buf), "%02X", raw & 0xFF);
+        v.text = buf; v.numeric = raw & 0xFF; v.numericMeaningful = true; break;
+    case WatchType::S8:
+        std::snprintf(buf, sizeof(buf), "%d", (int)(int8_t)raw);
+        v.text = buf; v.numeric = (int8_t)raw; v.numericMeaningful = true; break;
+    case WatchType::U16:
+        std::snprintf(buf, sizeof(buf), "%04X", raw & 0xFFFF);
+        v.text = buf; v.numeric = raw & 0xFFFF; v.numericMeaningful = true; break;
+    case WatchType::S16:
+        std::snprintf(buf, sizeof(buf), "%d", (int)(int16_t)raw);
+        v.text = buf; v.numeric = (int16_t)raw; v.numericMeaningful = true; break;
+    case WatchType::U32:
+        std::snprintf(buf, sizeof(buf), "%08X", raw);
+        v.text = buf; v.numeric = (long long)(uint32_t)raw; v.numericMeaningful = true; break;
+    case WatchType::S32:
+        std::snprintf(buf, sizeof(buf), "%d", (int32_t)raw);
+        v.text = buf; v.numeric = (int32_t)raw; v.numericMeaningful = true; break;
+    case WatchType::RGB555:
+    {
+        const uint16_t w = (uint16_t)(raw & 0xFFFF);
+        const int r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
+        std::snprintf(buf, sizeof(buf), "R%d G%d B%d", r5, g5, b5);
+        v.text = buf; v.hasSwatch = true; DecodeRgb555(w, v.r, v.g, v.b);
+        v.numeric = w; v.numericMeaningful = false;   // changed = neutral tint
+        break;
+    }
+    case WatchType::Pointer:
+        std::snprintf(buf, sizeof(buf), "-> 0x%08X", raw);
+        v.text = buf; v.isPointer = true; v.pointerTarget = raw;
+        v.pointerSuspicious = !IsPlausibleSaturnAddress(raw);
+        v.numeric = (long long)(uint32_t)raw; v.numericMeaningful = false;
+        break;
+    }
+    return v;
+}
+
+WatchEntry& WatchList::Add(const std::string& name, const std::string& expr,
+                           WatchType type, bool enabled)
+{
+    WatchEntry e;
+    e.id = mNextId++;
+    e.name = name;
+    e.expression = expr.empty() ? "0x06000000" : expr;
+    e.type = type;
+    e.enabled = enabled;
+    mEntries.push_back(std::move(e));
+    return mEntries.back();
+}
+
+void WatchList::RemoveAt(size_t i)
+{
+    if (i < mEntries.size()) mEntries.erase(mEntries.begin() + i);
+}
+
+// --- JSON --------------------------------------------------------------------
+
+namespace
+{
+void JsonEscape(const std::string& s, std::string& out)
+{
+    out.push_back('"');
+    for (char c : s)
+    {
+        switch (c)
+        {
+        case '"':  out += "\\\""; break;
+        case '\\': out += "\\\\"; break;
+        case '\n': out += "\\n";  break;
+        case '\r': out += "\\r";  break;
+        case '\t': out += "\\t";  break;
+        default:
+            if ((unsigned char)c < 0x20) { char b[8]; std::snprintf(b, sizeof(b), "\\u%04x", c); out += b; }
+            else out.push_back(c);
+        }
+    }
+    out.push_back('"');
+}
+
+// A tiny JSON parser (object/array/string/number/bool/null) — enough for the watch
+// schema, robust to whitespace, key order, and escaped strings.
+struct JVal
+{
+    enum T { Null, Bool, Num, Str, Arr, Obj } type = Null;
+    bool               b = false;
+    double             num = 0;
+    std::string        str;
+    std::vector<JVal>  arr;
+    std::vector<std::pair<std::string, JVal>> obj;
+
+    const JVal* Find(const char* key) const
+    {
+        for (auto& kv : obj) if (kv.first == key) return &kv.second;
+        return nullptr;
+    }
+};
+
+struct JParser
+{
+    const char* p;
+    const char* end;
+    bool ok = true;
+
+    void skip() { while (p < end && std::isspace((unsigned char)*p)) ++p; }
+    bool parse(JVal& v)
+    {
+        skip();
+        if (p >= end) return fail();
+        switch (*p)
+        {
+        case '{': return object(v);
+        case '[': return array(v);
+        case '"': return string(v);
+        case 't': case 'f': return boolean(v);
+        case 'n': return null(v);
+        default:  return number(v);
+        }
+    }
+    bool fail() { ok = false; return false; }
+    bool object(JVal& v)
+    {
+        v.type = JVal::Obj; ++p; skip();
+        if (p < end && *p == '}') { ++p; return true; }
+        while (p < end)
+        {
+            skip();
+            JVal key; if (!string(key)) return fail();
+            skip(); if (p >= end || *p != ':') return fail(); ++p;
+            JVal val; if (!parse(val)) return fail();
+            v.obj.emplace_back(key.str, std::move(val));
+            skip();
+            if (p < end && *p == ',') { ++p; continue; }
+            if (p < end && *p == '}') { ++p; return true; }
+            return fail();
+        }
+        return fail();
+    }
+    bool array(JVal& v)
+    {
+        v.type = JVal::Arr; ++p; skip();
+        if (p < end && *p == ']') { ++p; return true; }
+        while (p < end)
+        {
+            JVal e; if (!parse(e)) return fail();
+            v.arr.push_back(std::move(e));
+            skip();
+            if (p < end && *p == ',') { ++p; continue; }
+            if (p < end && *p == ']') { ++p; return true; }
+            return fail();
+        }
+        return fail();
+    }
+    bool string(JVal& v)
+    {
+        v.type = JVal::Str;
+        skip();
+        if (p >= end || *p != '"') return fail();
+        ++p;
+        while (p < end && *p != '"')
+        {
+            char c = *p++;
+            if (c == '\\' && p < end)
+            {
+                char e = *p++;
+                switch (e)
+                {
+                case 'n': v.str.push_back('\n'); break;
+                case 'r': v.str.push_back('\r'); break;
+                case 't': v.str.push_back('\t'); break;
+                case 'u': if (p + 4 <= end) p += 4; v.str.push_back('?'); break;
+                default:  v.str.push_back(e); break;
+                }
+            }
+            else v.str.push_back(c);
+        }
+        if (p >= end) return fail();
+        ++p;   // closing quote
+        return true;
+    }
+    bool boolean(JVal& v)
+    {
+        v.type = JVal::Bool;
+        if (end - p >= 4 && std::strncmp(p, "true", 4) == 0)  { v.b = true;  p += 4; return true; }
+        if (end - p >= 5 && std::strncmp(p, "false", 5) == 0) { v.b = false; p += 5; return true; }
+        return fail();
+    }
+    bool null(JVal& v)
+    {
+        v.type = JVal::Null;
+        if (end - p >= 4 && std::strncmp(p, "null", 4) == 0) { p += 4; return true; }
+        return fail();
+    }
+    bool number(JVal& v)
+    {
+        v.type = JVal::Num;
+        char* e = nullptr;
+        v.num = std::strtod(p, &e);
+        if (e == p) return fail();
+        p = e;
+        return true;
+    }
+};
+}  // namespace
+
+std::string WatchList::ToJson() const
+{
+    std::string out = "{\n  \"version\": 1,\n  \"watches\": [";
+    for (size_t i = 0; i < mEntries.size(); ++i)
+    {
+        const WatchEntry& e = mEntries[i];
+        out += (i == 0) ? "\n" : ",\n";
+        out += "    { \"name\": ";
+        JsonEscape(e.name, out);
+        out += ", \"expression\": ";
+        JsonEscape(e.expression, out);
+        out += ", \"type\": ";
+        JsonEscape(WatchTypeName(e.type), out);
+        out += ", \"enabled\": ";
+        out += e.enabled ? "true" : "false";
+        out += " }";
+    }
+    out += mEntries.empty() ? "]\n}\n" : "\n  ]\n}\n";
+    return out;
+}
+
+int WatchList::FromJson(const std::string& json, std::vector<std::string>& errors)
+{
+    JParser jp{ json.c_str(), json.c_str() + json.size() };
+    JVal doc;
+    if (!jp.parse(doc) || doc.type != JVal::Obj)
+    {
+        errors.push_back("File is not valid JSON.");
+        return -1;
+    }
+    const JVal* ver = doc.Find("version");
+    if (!ver || ver->type != JVal::Num || (int)ver->num != 1)
+    {
+        errors.push_back("Unsupported or missing \"version\" (expected 1).");
+        return -1;
+    }
+    const JVal* watches = doc.Find("watches");
+    if (!watches || watches->type != JVal::Arr)
+    {
+        errors.push_back("Missing \"watches\" array.");
+        return -1;
+    }
+
+    std::vector<WatchEntry> imported;
+    int index = 0;
+    for (const JVal& w : watches->arr)
+    {
+        ++index;
+        if (w.type != JVal::Obj) { errors.push_back("Entry " + std::to_string(index) + ": not an object."); continue; }
+        const JVal* name = w.Find("name");
+        const JVal* expr = w.Find("expression");
+        const JVal* type = w.Find("type");
+        const JVal* en   = w.Find("enabled");
+        if (!expr || expr->type != JVal::Str)
+        { errors.push_back("Entry " + std::to_string(index) + ": missing \"expression\"."); continue; }
+        WatchType t = WatchType::U16;
+        if (type && type->type == JVal::Str && !WatchTypeFromName(type->str.c_str(), t))
+        { errors.push_back("Entry " + std::to_string(index) + ": unknown type \"" + type->str + "\", using U16."); }
+        WatchEntry e;
+        e.id = mNextId++;
+        e.name = (name && name->type == JVal::Str) ? name->str : "";
+        e.expression = expr->str;
+        e.type = t;
+        e.enabled = en ? (en->type == JVal::Bool ? en->b : true) : true;
+        imported.push_back(std::move(e));
+    }
+    mEntries = std::move(imported);
+    return (int)mEntries.size();
+}
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/Debug/WatchList.h
+++ b/SaturnExplorer/FrontEnd/src/Debug/WatchList.h
@@ -1,0 +1,110 @@
+// WatchList — the persistent + runtime model behind the Watch Window. Holds the
+// user's watch entries, resolves their address expressions, formats their values
+// (big-endian, per the user-chosen type), and serializes to/from JSON. No ImGui
+// here; the panel renders this and the ContextBackend feeds it bytes.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Debug/MemoryBackend.h"
+
+namespace sfe
+{
+
+enum class WatchType
+{
+    U8, S8, U16, S16, U32, S32, RGB555, Pointer
+};
+
+// Type metadata (kept in one place so the dropdown, byte size, and breakpoint size
+// all agree).
+const char*  WatchTypeName(WatchType t);            // "U16"
+uint32_t     WatchTypeSize(WatchType t);            // bytes read (1/2/4)
+bool         WatchTypeFromName(const char* s, WatchType& out);
+extern const WatchType kAllWatchTypes[8];
+
+// One watch. Name/expression/type/enabled persist; the rest is transient runtime
+// state (resolved address, last value, change highlight) and is not serialized.
+struct WatchEntry
+{
+    uint64_t    id = 0;              // stable, for stale-response matching
+    std::string name;
+    std::string expression = "0x06000000";
+    WatchType   type = WatchType::U16;
+    bool        enabled = true;
+
+    // Runtime (updated by the refresh loop / panel).
+    bool        resolved = false;
+    uint32_t    address = 0;
+    std::string resolveError;       // set when the expression is invalid
+};
+
+// Address-expression resolver seam: today "0xADDR [+|- N]"; later symbols/pointers.
+class IExpressionResolver
+{
+public:
+    virtual ~IExpressionResolver() = default;
+    // Returns true and sets 'outAddr' on success; false with 'outError' otherwise.
+    virtual bool Resolve(const std::string& expr, uint32_t& outAddr,
+                         std::string& outError) = 0;
+};
+
+// Default resolver: a base hex address plus an optional single +/- offset
+// (hex with 0x, decimal otherwise). No scripting, no side effects.
+class SimpleExpressionResolver : public IExpressionResolver
+{
+public:
+    bool Resolve(const std::string& expr, uint32_t& outAddr,
+                 std::string& outError) override;
+};
+
+// Normalize a pure-address token to 0xXXXXXXXX (upper). Non-address expressions
+// (containing +/-) are returned trimmed but otherwise unchanged.
+std::string NormalizeExpression(const std::string& expr);
+
+// The formatted value of a watch, ready for the table cell.
+struct WatchValue
+{
+    bool        valid = false;      // false -> show 'text' (e.g. "Invalid address")
+    std::string text;               // "7FFF", "-128", "R31 G14 B28", "-> 0x06025040"
+    bool        hasSwatch = false;  // RGB555: draw a colour chip
+    uint8_t     r = 0, g = 0, b = 0;
+    bool        isPointer = false;
+    uint32_t    pointerTarget = 0;
+    bool        pointerSuspicious = false;   // outside known Saturn ranges
+    // For the change highlight: a signed magnitude and whether up/down is meaningful.
+    long long   numeric = 0;
+    bool        numericMeaningful = false;
+};
+
+// Interpret 'bytes' (big-endian, WatchTypeSize(type) long) as 'type'.
+WatchValue FormatWatchValue(WatchType type, const MemoryReadResult& mem);
+
+// Is 'addr' inside a plausible Saturn CPU region (for the pointer sanity check)?
+bool IsPlausibleSaturnAddress(uint32_t addr);
+
+class WatchList
+{
+public:
+    std::vector<WatchEntry>& Entries() { return mEntries; }
+    const std::vector<WatchEntry>& Entries() const { return mEntries; }
+
+    WatchEntry& Add(const std::string& name, const std::string& expr,
+                    WatchType type, bool enabled);
+    void RemoveAt(size_t i);
+    void Clear() { mEntries.clear(); }
+
+    std::string ToJson() const;
+    // Replaces the list on success. Skipped/invalid entries are appended to
+    // 'errors' (one line each) but do not abort the import. Returns imported count,
+    // or -1 if the document itself is unparseable / wrong version.
+    int FromJson(const std::string& json, std::vector<std::string>& errors);
+
+private:
+    std::vector<WatchEntry> mEntries;
+    uint64_t                mNextId = 1;
+};
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/SaturnRegions.h
+++ b/SaturnExplorer/FrontEnd/src/SaturnRegions.h
@@ -16,4 +16,14 @@ constexpr uint32_t kWramSize     = 0x100000;  // work RAM, low and high (each)
 constexpr uint32_t kVdp1FbSize   = 0x40000;   // VDP1 frame buffer (drawn output)
 constexpr uint32_t kVdp1RegBytes = 0x18;      // VDP1 register image (TVMR..MODR)
 constexpr uint32_t kVdp2RegBytes = 0x120;     // VDP2 register file
+
+// Expand a Saturn RGB555 word to 8-bit-per-channel (the one place the 5->8 bit
+// replication lives, shared by the palette/FB/watch views).
+inline void DecodeRgb555(uint16_t w, uint8_t& r, uint8_t& g, uint8_t& b)
+{
+    const uint8_t r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
+    r = static_cast<uint8_t>((r5 << 3) | (r5 >> 2));
+    g = static_cast<uint8_t>((g5 << 3) | (g5 >> 2));
+    b = static_cast<uint8_t>((b5 << 3) | (b5 >> 2));
+}
 }  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/WatchPanel.cpp
+++ b/SaturnExplorer/FrontEnd/src/WatchPanel.cpp
@@ -1,0 +1,349 @@
+#include "WatchPanel.h"
+
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+namespace sfe
+{
+
+namespace
+{
+const char* kSessionFile = "saturn_explorer_watches.json";
+
+// Change-highlight base colours (alpha applied from the fade timer).
+constexpr ImU32 kUpCol      = IM_COL32(40, 150, 70, 255);    // value increased
+constexpr ImU32 kDownCol    = IM_COL32(175, 55, 55, 255);    // value decreased
+constexpr ImU32 kNeutralCol = IM_COL32(170, 150, 45, 255);   // changed, no direction
+
+void CopyStr(char* dst, size_t cap, const std::string& s)
+{
+    const size_t n = s.size() < cap - 1 ? s.size() : cap - 1;
+    std::memcpy(dst, s.data(), n);
+    dst[n] = '\0';
+}
+}  // namespace
+
+WatchPanel::WatchPanel() = default;
+
+WatchPanel::Row& WatchPanel::RowFor(const WatchEntry& e)
+{
+    Row& row = mRows[e.id];
+    if (!row.seeded)
+    {
+        CopyStr(row.nameBuf, sizeof(row.nameBuf), e.name);
+        CopyStr(row.exprBuf, sizeof(row.exprBuf), e.expression);
+        row.seeded = true;
+    }
+    return row;
+}
+
+void WatchPanel::Refresh(IMemoryBackend& backend, IExpressionResolver& resolver)
+{
+    std::vector<MemoryReadRequest> reqs;
+    std::vector<uint64_t>          ids;
+    std::vector<WatchType>         types;
+
+    for (WatchEntry& e : mList.Entries())
+    {
+        Row& row = RowFor(e);
+        uint32_t addr = 0;
+        std::string err;
+        if (resolver.Resolve(row.exprBuf, addr, err))
+        {
+            row.resolved = true;
+            row.address = addr;
+            row.error.clear();
+        }
+        else
+        {
+            row.resolved = false;
+            row.error = err;
+            row.hasValue = false;
+            row.value = WatchValue{};
+            continue;
+        }
+        if (!e.enabled) { continue; }
+        reqs.push_back({ addr, WatchTypeSize(e.type) });
+        ids.push_back(e.id);
+        types.push_back(e.type);
+    }
+
+    // One batched request set per refresh (not one call per watch). The backend is
+    // synchronous here — it copies from the already-captured snapshot — so there is
+    // no async response to race; an async remote backend would add a generation
+    // guard at this seam.
+    const std::vector<MemoryReadResult> results = backend.ReadMemoryBatch(reqs);
+    for (size_t k = 0; k < results.size() && k < ids.size(); ++k)
+    {
+        Row& row = mRows[ids[k]];
+        WatchValue v = FormatWatchValue(types[k], results[k]);
+        if (v.valid)
+        {
+            if (row.hasLast && v.numeric != row.lastNumeric)
+            {
+                row.highlightCol = !v.numericMeaningful ? kNeutralCol
+                                 : (v.numeric > row.lastNumeric ? kUpCol : kDownCol);
+                row.highlight = 1.0f;
+            }
+            row.lastNumeric = v.numeric;
+            row.hasLast = true;
+        }
+        row.value = std::move(v);
+        row.hasValue = true;
+    }
+}
+
+void WatchPanel::Draw(IMemoryBackend& backend, IExpressionResolver& resolver,
+                      IPlatform& platform, float dt)
+{
+    if (!ImGui::Begin("Watch"))
+    {
+        ImGui::End();
+        return;
+    }
+
+    // Refresh values at ~mRefreshHz; fade highlights every frame.
+    mRefreshAccum += dt;
+    const float period = mRefreshHz > 0.0f ? 1.0f / mRefreshHz : 0.1f;
+    if (mRefreshAccum >= period)
+    {
+        mRefreshAccum = 0.0f;
+        Refresh(backend, resolver);
+    }
+    for (auto& kv : mRows)
+    {
+        if (kv.second.highlight > 0.0f) kv.second.highlight -= dt;
+    }
+
+    // --- Toolbar ---
+    if (ImGui::Button("+ Add Watch"))
+    {
+        mList.Add("", "0x06000000", WatchType::U16, true);
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Import")) DoImport(platform);
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Load a watch list (JSON).");
+    ImGui::SameLine();
+    if (ImGui::Button("Export")) DoExport(platform);
+    if (ImGui::IsItemHovered()) ImGui::SetTooltip("Save the watch list (JSON).");
+    ImGui::SameLine();
+    if (ImGui::Button("Clear All")) { mList.Clear(); mRows.clear(); }
+    ImGui::SameLine();
+    if (!backend.Connected()) { ImGui::TextDisabled("(disconnected)"); }
+    else                      { ImGui::TextDisabled("%d watches", (int)mList.Entries().size()); }
+
+    if (!mNotice.empty())
+    {
+        mNoticeTime -= dt;
+        if (mNoticeTime <= 0.0f) mNotice.clear();
+        else ImGui::TextWrapped("%s", mNotice.c_str());
+    }
+
+    // --- Table ---
+    const ImGuiTableFlags flags = ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY |
+                                  ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInnerV;
+    if (!ImGui::BeginTable("watches", 6, flags))
+    {
+        ImGui::End();
+        return;
+    }
+    ImGui::TableSetupScrollFreeze(0, 1);
+    ImGui::TableSetupColumn("##en", ImGuiTableColumnFlags_WidthFixed, 22.0f);
+    ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch, 0.25f);
+    ImGui::TableSetupColumn("Address / Expression", ImGuiTableColumnFlags_WidthStretch, 0.35f);
+    ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthStretch, 0.15f);
+    ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch, 0.25f);
+    ImGui::TableSetupColumn("##opt", ImGuiTableColumnFlags_WidthFixed, 26.0f);
+    ImGui::TableHeadersRow();
+
+    int deleteIndex = -1;
+    auto& entries = mList.Entries();
+    for (size_t i = 0; i < entries.size(); ++i)
+    {
+        WatchEntry& e = entries[i];
+        Row& row = RowFor(e);
+        ImGui::PushID((int)e.id);
+        ImGui::TableNextRow();
+
+        // Enabled.
+        ImGui::TableSetColumnIndex(0);
+        ImGui::Checkbox("##en", &e.enabled);
+
+        // Name (borderless inline edit).
+        ImGui::TableSetColumnIndex(1);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 0));
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (mFocusNameRow == (int)i) { ImGui::SetKeyboardFocusHere(); mFocusNameRow = -1; }
+        if (ImGui::InputText("##name", row.nameBuf, sizeof(row.nameBuf)))
+        { /* live edit; commit below */ }
+        if (ImGui::IsItemDeactivatedAfterEdit()) e.name = row.nameBuf;
+
+        // Address / Expression (borderless inline edit; normalize + resolve on commit).
+        ImGui::TableSetColumnIndex(2);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputText("##expr", row.exprBuf, sizeof(row.exprBuf),
+                         ImGuiInputTextFlags_CharsNoBlank);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+        {
+            std::string norm = NormalizeExpression(row.exprBuf);
+            CopyStr(row.exprBuf, sizeof(row.exprBuf), norm);
+            e.expression = norm;
+            Refresh(backend, resolver);   // reflect the change immediately
+        }
+        ImGui::PopStyleColor();
+
+        // Type (dropdown; commits on selection).
+        ImGui::TableSetColumnIndex(3);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::BeginCombo("##type", WatchTypeName(e.type)))
+        {
+            for (WatchType t : kAllWatchTypes)
+            {
+                const bool sel = (t == e.type);
+                if (ImGui::Selectable(WatchTypeName(t), sel))
+                {
+                    e.type = t;
+                    Refresh(backend, resolver);
+                }
+                if (sel) ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+
+        // Value (+ swatch, change highlight, error tooltip).
+        ImGui::TableSetColumnIndex(4);
+        if (row.highlight > 0.0f)
+        {
+            const int alpha = (int)(row.highlight * 140.0f);
+            const ImU32 col = (row.highlightCol & 0x00FFFFFFu) |
+                              ((alpha < 0 ? 0 : alpha) << 24);
+            ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, col);
+        }
+        if (!e.enabled)
+        {
+            ImGui::TextDisabled("(disabled)");
+        }
+        else if (!row.resolved)
+        {
+            ImGui::TextColored(ImVec4(0.85f, 0.4f, 0.4f, 1.0f), "Invalid address");
+            if (ImGui::IsItemHovered() && !row.error.empty())
+                ImGui::SetTooltip("%s", row.error.c_str());
+        }
+        else if (!row.hasValue || !row.value.valid)
+        {
+            ImGui::TextColored(ImVec4(0.8f, 0.55f, 0.35f, 1.0f), "%s",
+                               row.hasValue ? row.value.text.c_str() : "Unavailable");
+        }
+        else
+        {
+            const WatchValue& v = row.value;
+            if (v.hasSwatch)
+            {
+                ImVec2 p = ImGui::GetCursorScreenPos();
+                const float h = ImGui::GetTextLineHeight();
+                ImGui::GetWindowDrawList()->AddRectFilled(
+                    p, ImVec2(p.x + h, p.y + h), IM_COL32(v.r, v.g, v.b, 255));
+                ImGui::GetWindowDrawList()->AddRect(
+                    p, ImVec2(p.x + h, p.y + h), IM_COL32(20, 20, 24, 255));
+                ImGui::Dummy(ImVec2(h + 4.0f, h));
+                ImGui::SameLine();
+            }
+            ImGui::TextUnformatted(v.text.c_str());
+            if (v.isPointer && v.pointerSuspicious && ImGui::IsItemHovered())
+                ImGui::SetTooltip("Target 0x%08X is outside known Saturn RAM/VRAM ranges.",
+                                  v.pointerTarget);
+        }
+
+        // Options (overflow menu).
+        ImGui::TableSetColumnIndex(5);
+        if (ImGui::SmallButton("...")) ImGui::OpenPopup("rowmenu");
+        if (ImGui::BeginPopup("rowmenu"))
+        {
+            if (ImGui::MenuItem("Edit"))            mFocusNameRow = (int)i;
+            if (ImGui::MenuItem("Delete"))          deleteIndex = (int)i;
+            if (ImGui::MenuItem(e.enabled ? "Disable" : "Enable")) e.enabled = !e.enabled;
+            ImGui::Separator();
+            if (ImGui::MenuItem("Copy Address"))
+            {
+                char b[16]; std::snprintf(b, sizeof(b), "0x%08X", row.address);
+                ImGui::SetClipboardText(row.resolved ? b : e.expression.c_str());
+            }
+            if (ImGui::MenuItem("Copy Value", nullptr, false, row.hasValue))
+                ImGui::SetClipboardText(row.value.text.c_str());
+            ImGui::Separator();
+            ImGui::BeginDisabled();
+            ImGui::MenuItem("View in Hex Editor");
+            ImGui::MenuItem("Break on Read");
+            ImGui::MenuItem("Break on Write");
+            ImGui::MenuItem("Break on Read or Write");
+            ImGui::EndDisabled();
+            ImGui::TextDisabled("  (hex editor + breakpoints: later phase)");
+            ImGui::EndPopup();
+        }
+
+        ImGui::PopID();
+    }
+    ImGui::EndTable();
+
+    if (deleteIndex >= 0)
+    {
+        const uint64_t id = entries[(size_t)deleteIndex].id;
+        mRows.erase(id);
+        mList.RemoveAt((size_t)deleteIndex);
+    }
+
+    ImGui::End();
+}
+
+void WatchPanel::DoImport(IPlatform& platform)
+{
+    std::string path;
+    if (!platform.OpenFileDialog(path)) return;
+    std::ifstream f(path, std::ios::binary);
+    if (!f) { mNotice = "Import failed: cannot open file."; mNoticeTime = 6.0f; return; }
+    std::stringstream ss; ss << f.rdbuf();
+    std::vector<std::string> errors;
+    const int n = mList.FromJson(ss.str(), errors);
+    mRows.clear();   // reseed row buffers from the new model
+    if (n < 0)
+    {
+        mNotice = "Import failed: " + (errors.empty() ? std::string("invalid file.") : errors[0]);
+    }
+    else
+    {
+        mNotice = "Imported " + std::to_string(n) + " watches";
+        if (!errors.empty())
+            mNotice += " (" + std::to_string(errors.size()) + " skipped: " + errors[0] + ")";
+    }
+    mNoticeTime = 6.0f;
+}
+
+void WatchPanel::DoExport(IPlatform& platform)
+{
+    const std::string json = mList.ToJson();
+    if (platform.SaveFile("watches.json", json.data(), json.size()))
+    {
+        mNotice = "Exported " + std::to_string(mList.Entries().size()) + " watches";
+        mNoticeTime = 4.0f;
+    }
+}
+
+void WatchPanel::LoadSession()
+{
+    std::ifstream f(kSessionFile, std::ios::binary);
+    if (!f) return;
+    std::stringstream ss; ss << f.rdbuf();
+    std::vector<std::string> errors;
+    mList.FromJson(ss.str(), errors);
+    mRows.clear();
+}
+
+void WatchPanel::SaveSession() const
+{
+    std::ofstream f(kSessionFile, std::ios::binary);
+    if (f) f << mList.ToJson();
+}
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/WatchPanel.h
+++ b/SaturnExplorer/FrontEnd/src/WatchPanel.h
@@ -1,0 +1,69 @@
+// WatchPanel — the Watch Window UI. Owns the WatchList, renders the toolbar +
+// table, drives the ~10 Hz batched refresh through an IMemoryBackend, and does
+// inline editing, change highlighting, context menu, and JSON import/export.
+// Emulator-agnostic: it talks to IMemoryBackend / IExpressionResolver only.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "imgui.h"
+
+#include "Debug/WatchList.h"
+#include "Debug/MemoryBackend.h"
+#include "Platform/IPlatform.h"
+
+namespace sfe
+{
+
+class WatchPanel
+{
+public:
+    WatchPanel();
+
+    // Draw the "Watch" window. 'dt' is the frame delta (seconds) for the refresh
+    // timer + highlight fade. Reads values via 'backend', resolves expressions via
+    // 'resolver', and uses 'platform' for import/export file dialogs.
+    void Draw(IMemoryBackend& backend, IExpressionResolver& resolver,
+              IPlatform& platform, float dt);
+
+    // Session persistence: load/save the watch list to a file in the working dir.
+    void LoadSession();
+    void SaveSession() const;
+
+private:
+    struct Row
+    {
+        bool        seeded = false;
+        char        nameBuf[128] = {};
+        char        exprBuf[64] = {};
+        // Resolution + last read.
+        bool        resolved = false;
+        uint32_t    address = 0;
+        std::string error;
+        WatchValue  value;
+        bool        hasValue = false;
+        // Change highlight.
+        bool        hasLast = false;
+        long long   lastNumeric = 0;
+        float       highlight = 0.0f;     // seconds remaining (fades 1 -> 0)
+        ImU32       highlightCol = 0;
+    };
+
+    void Refresh(IMemoryBackend& backend, IExpressionResolver& resolver);
+    Row& RowFor(const WatchEntry& e);
+    void DoImport(IPlatform& platform);
+    void DoExport(IPlatform& platform);
+
+    WatchList mList;
+    std::unordered_map<uint64_t, Row> mRows;   // by entry id
+    float     mRefreshAccum = 0.0f;
+    float     mRefreshHz = 10.0f;
+    int       mContextRow = -1;                // row index whose menu is open
+    int       mFocusNameRow = -1;              // "Edit" jumped focus here
+    std::string mNotice;                        // one-line status (import/export)
+    float     mNoticeTime = 0.0f;
+};
+
+}  // namespace sfe


### PR DESCRIPTION
First phase of the Watch Window / SH-2 Assembly work. Replaces the redundant right-column **Palette (CLUT)** / **Texture Preview** panels (they duplicated the center viewers) with a **Watch Window** and a docked **SH-2 Assembly** placeholder.

### Watch Window (emulator-agnostic)
- **`IMemoryBackend`** interface + **`ContextBackend`** that reads any Saturn address from the current `se_context` (live snapshot or paused scrub), mapping mirror-normalized addresses to WRAM / VRAM / CRAM / VDP registers. Batched `ReadMemoryBatch`. No emulator-specific code in the UI — Yabause stays behind the LiveDriver/`se_context` seam.
- **8 user-chosen types** — U8/S8/U16/S16/U32/S32/RGB555/Pointer — interpreted **big-endian**. RGB555 shows `R/G/B` + a colour swatch (via a shared `DecodeRgb555`); Pointer shows `-> target` and flags addresses outside known Saturn ranges.
- Toolbar (Add / Import / Export / Clear All); table with inline name/address edit and a type dropdown; expression resolver seam (`0xADDR ± N`, no scripting); **~10 Hz batched refresh**; change-highlight fade (green up / red down / neutral); context menu (edit, delete, enable/disable, copy address/value — hex-editor + break-on-* present but disabled for later phases); **JSON import/export** with per-entry validation (skip + report, never abort); session persistence.
- Degrades cleanly: `Unavailable` / `Invalid address` in the value cell, tooltips, never a modal or crash.

### SH-2 Assembly
A docked placeholder describing its dependency — needs SH-2 register/PC + breakpoint export from Yabause (protocol update + rebuild) and the disassembler — so the layout is finalized now. Later phases fill it in.

### What's deferred (needs Yabause-side work)
SH-2 disassembler (Phase 2), CPU-state export + live Assembly view (Phase 3), breakpoint manager + execution/memory breakpoints (Phase 4), Hex Editor + cross-panel wiring (Phase 5). The Watch context-menu items that depend on those are present but disabled.

### Verification
- Model unit tests pass: expression resolver, big-endian value formatting (incl. RGB555/Pointer/signed), JSON round-trip + skip-invalid + bad-version, address mapping + cache-mirror fold, graceful WRAM-absent.
- Desktop links (with `SE_ENABLE_LIVE`); web/no-live config compiles.
- Headless render against a real savestate shows every value type formatting correctly (RGB555 swatch, hex, `Unavailable` for live-only WRAM, suspicious Pointer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_