### PR TITLE
Debugger Phase 2: SH-2 disassembler (core, unit-tested)

### DIFF
--- a/SaturnExplorer/CMakeLists.txt
+++ b/SaturnExplorer/CMakeLists.txt
@@ -111,6 +111,7 @@ if(WIN32)
         FrontEnd/src/WatchPanel.cpp
         FrontEnd/src/Debug/WatchList.cpp
         FrontEnd/src/Debug/MemoryBackend.cpp
+        FrontEnd/src/Debug/Sh2Disasm.cpp
         FrontEnd/src/FrameRecorder.cpp
         FrontEnd/src/FrameLz.cpp
         FrontEnd/Platforms/Windows/WindowsPlatform.cpp
@@ -151,6 +152,7 @@ elseif(EMSCRIPTEN)
         FrontEnd/src/WatchPanel.cpp
         FrontEnd/src/Debug/WatchList.cpp
         FrontEnd/src/Debug/MemoryBackend.cpp
+        FrontEnd/src/Debug/Sh2Disasm.cpp
         FrontEnd/Platforms/Web/WebPlatform.cpp
         FrontEnd/Platforms/Web/WebMain.cpp
         ${SE_IMGUI_CORE}
@@ -193,6 +195,7 @@ else()
             FrontEnd/src/WatchPanel.cpp
             FrontEnd/src/Debug/WatchList.cpp
             FrontEnd/src/Debug/MemoryBackend.cpp
+            FrontEnd/src/Debug/Sh2Disasm.cpp
             FrontEnd/src/FrameRecorder.cpp
             FrontEnd/src/FrameLz.cpp
             FrontEnd/Platforms/Web/WebPlatform.cpp

--- a/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.cpp
@@ -1,0 +1,292 @@
+#include "Debug/Sh2Disasm.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace sfe
+{
+
+namespace
+{
+// Small operand formatter into the instruction, keeping call sites terse.
+struct Out
+{
+    DisassembledInstruction& ins;
+    void set(const char* mn) { ins.Mnemonic = mn; ins.IsValid = true; }
+    void ops(const char* fmt, ...)
+    {
+        char buf[64];
+        va_list ap; va_start(ap, fmt);
+        std::vsnprintf(buf, sizeof(buf), fmt, ap);
+        va_end(ap);
+        ins.Operands = buf;
+    }
+};
+
+int8_t  s8(uint16_t v)  { return (int8_t)(v & 0xFF); }
+int32_t s12(uint16_t v) { int32_t d = v & 0xFFF; if (d & 0x800) d |= ~0xFFF; return d; }
+int32_t s8ext(uint16_t v){ return (int32_t)s8(v); }
+}  // namespace
+
+DisassembledInstruction Sh2Decode(uint32_t address, uint16_t op)
+{
+    DisassembledInstruction ins;
+    ins.Address = address;
+    ins.Opcode = op;
+    Out o{ ins };
+
+    const int n = (op >> 8) & 0xF;
+    const int m = (op >> 4) & 0xF;
+    const int imm = op & 0xFF;
+    const int d4 = op & 0xF;
+
+    switch (op >> 12)
+    {
+    case 0x0:
+        switch (op & 0xF)
+        {
+        case 0x2:
+            switch (m) {
+            case 0: o.set("stc");  o.ops("sr,r%d", n);  return ins;
+            case 1: o.set("stc");  o.ops("gbr,r%d", n); return ins;
+            case 2: o.set("stc");  o.ops("vbr,r%d", n); return ins;
+            }
+            break;
+        case 0x3:
+            switch (m) {
+            case 0: o.set("bsrf"); o.ops("r%d", n); ins.IsBranch = ins.IsCall = true; return ins;
+            case 2: o.set("braf"); o.ops("r%d", n); ins.IsBranch = true; return ins;
+            }
+            break;
+        case 0x4: o.set("mov.b"); o.ops("r%d,@(r0,r%d)", m, n); return ins;
+        case 0x5: o.set("mov.w"); o.ops("r%d,@(r0,r%d)", m, n); return ins;
+        case 0x6: o.set("mov.l"); o.ops("r%d,@(r0,r%d)", m, n); return ins;
+        case 0x7: o.set("mul.l"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x8:
+            switch (op) {
+            case 0x0008: o.set("clrt");  ins.Operands.clear(); return ins;
+            case 0x0018: o.set("sett");  ins.Operands.clear(); return ins;
+            case 0x0028: o.set("clrmac");ins.Operands.clear(); return ins;
+            }
+            break;
+        case 0x9:
+            if (op == 0x0009) { o.set("nop");   ins.Operands.clear(); return ins; }
+            if (op == 0x0019) { o.set("div0u"); ins.Operands.clear(); return ins; }
+            if ((op & 0xF0FF) == 0x0029) { o.set("movt"); o.ops("r%d", n); return ins; }
+            break;
+        case 0xA:
+            switch (m) {
+            case 0: o.set("sts"); o.ops("mach,r%d", n); return ins;
+            case 1: o.set("sts"); o.ops("macl,r%d", n); return ins;
+            case 2: o.set("sts"); o.ops("pr,r%d", n);   return ins;
+            }
+            break;
+        case 0xB:
+            switch (op) {
+            case 0x000B: o.set("rts");   ins.Operands.clear(); ins.IsBranch = ins.IsReturn = true; return ins;
+            case 0x001B: o.set("sleep"); ins.Operands.clear(); return ins;
+            case 0x002B: o.set("rte");   ins.Operands.clear(); ins.IsBranch = ins.IsReturn = true; return ins;
+            }
+            break;
+        case 0xC: o.set("mov.b"); o.ops("@(r0,r%d),r%d", m, n); return ins;
+        case 0xD: o.set("mov.w"); o.ops("@(r0,r%d),r%d", m, n); return ins;
+        case 0xE: o.set("mov.l"); o.ops("@(r0,r%d),r%d", m, n); return ins;
+        case 0xF: o.set("mac.l"); o.ops("@r%d+,@r%d+", m, n); return ins;
+        }
+        break;
+
+    case 0x1:  o.set("mov.l"); o.ops("r%d,@(0x%X,r%d)", m, d4 * 4, n); return ins;
+
+    case 0x2:
+        switch (op & 0xF) {
+        case 0x0: o.set("mov.b");  o.ops("r%d,@r%d", m, n); return ins;
+        case 0x1: o.set("mov.w");  o.ops("r%d,@r%d", m, n); return ins;
+        case 0x2: o.set("mov.l");  o.ops("r%d,@r%d", m, n); return ins;
+        case 0x4: o.set("mov.b");  o.ops("r%d,@-r%d", m, n); return ins;
+        case 0x5: o.set("mov.w");  o.ops("r%d,@-r%d", m, n); return ins;
+        case 0x6: o.set("mov.l");  o.ops("r%d,@-r%d", m, n); return ins;
+        case 0x7: o.set("div0s");  o.ops("r%d,r%d", m, n); return ins;
+        case 0x8: o.set("tst");    o.ops("r%d,r%d", m, n); return ins;
+        case 0x9: o.set("and");    o.ops("r%d,r%d", m, n); return ins;
+        case 0xA: o.set("xor");    o.ops("r%d,r%d", m, n); return ins;
+        case 0xB: o.set("or");     o.ops("r%d,r%d", m, n); return ins;
+        case 0xC: o.set("cmp/str");o.ops("r%d,r%d", m, n); return ins;
+        case 0xD: o.set("xtrct");  o.ops("r%d,r%d", m, n); return ins;
+        case 0xE: o.set("mulu.w"); o.ops("r%d,r%d", m, n); return ins;
+        case 0xF: o.set("muls.w"); o.ops("r%d,r%d", m, n); return ins;
+        }
+        break;
+
+    case 0x3:
+        switch (op & 0xF) {
+        case 0x0: o.set("cmp/eq"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x2: o.set("cmp/hs"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x3: o.set("cmp/ge"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x4: o.set("div1");   o.ops("r%d,r%d", m, n); return ins;
+        case 0x5: o.set("dmulu.l");o.ops("r%d,r%d", m, n); return ins;
+        case 0x6: o.set("cmp/hi"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x7: o.set("cmp/gt"); o.ops("r%d,r%d", m, n); return ins;
+        case 0x8: o.set("sub");    o.ops("r%d,r%d", m, n); return ins;
+        case 0xA: o.set("subc");   o.ops("r%d,r%d", m, n); return ins;
+        case 0xB: o.set("subv");   o.ops("r%d,r%d", m, n); return ins;
+        case 0xC: o.set("add");    o.ops("r%d,r%d", m, n); return ins;
+        case 0xD: o.set("dmuls.l");o.ops("r%d,r%d", m, n); return ins;
+        case 0xE: o.set("addc");   o.ops("r%d,r%d", m, n); return ins;
+        case 0xF: o.set("addv");   o.ops("r%d,r%d", m, n); return ins;
+        }
+        break;
+
+    case 0x4:
+        switch (op & 0xFF) {
+        case 0x00: o.set("shll");  o.ops("r%d", n); return ins;
+        case 0x01: o.set("shlr");  o.ops("r%d", n); return ins;
+        case 0x02: o.set("sts.l"); o.ops("mach,@-r%d", n); return ins;
+        case 0x03: o.set("stc.l"); o.ops("sr,@-r%d", n); return ins;
+        case 0x04: o.set("rotl");  o.ops("r%d", n); return ins;
+        case 0x05: o.set("rotr");  o.ops("r%d", n); return ins;
+        case 0x06: o.set("lds.l"); o.ops("@r%d+,mach", n); return ins;
+        case 0x07: o.set("ldc.l"); o.ops("@r%d+,sr", n); return ins;
+        case 0x08: o.set("shll2"); o.ops("r%d", n); return ins;
+        case 0x09: o.set("shlr2"); o.ops("r%d", n); return ins;
+        case 0x0A: o.set("lds");   o.ops("r%d,mach", n); return ins;
+        case 0x0B: o.set("jsr");   o.ops("@r%d", n); ins.IsBranch = ins.IsCall = true; return ins;
+        case 0x0E: o.set("ldc");   o.ops("r%d,sr", n); return ins;
+        case 0x10: o.set("dt");    o.ops("r%d", n); return ins;
+        case 0x11: o.set("cmp/pz");o.ops("r%d", n); return ins;
+        case 0x12: o.set("sts.l"); o.ops("macl,@-r%d", n); return ins;
+        case 0x13: o.set("stc.l"); o.ops("gbr,@-r%d", n); return ins;
+        case 0x15: o.set("cmp/pl");o.ops("r%d", n); return ins;
+        case 0x16: o.set("lds.l"); o.ops("@r%d+,macl", n); return ins;
+        case 0x17: o.set("ldc.l"); o.ops("@r%d+,gbr", n); return ins;
+        case 0x18: o.set("shll8"); o.ops("r%d", n); return ins;
+        case 0x19: o.set("shlr8"); o.ops("r%d", n); return ins;
+        case 0x1A: o.set("lds");   o.ops("r%d,macl", n); return ins;
+        case 0x1B: o.set("tas.b"); o.ops("@r%d", n); return ins;
+        case 0x1E: o.set("ldc");   o.ops("r%d,gbr", n); return ins;
+        case 0x20: o.set("shal");  o.ops("r%d", n); return ins;
+        case 0x21: o.set("shar");  o.ops("r%d", n); return ins;
+        case 0x22: o.set("sts.l"); o.ops("pr,@-r%d", n); return ins;
+        case 0x23: o.set("stc.l"); o.ops("vbr,@-r%d", n); return ins;
+        case 0x24: o.set("rotcl"); o.ops("r%d", n); return ins;
+        case 0x25: o.set("rotcr"); o.ops("r%d", n); return ins;
+        case 0x26: o.set("lds.l"); o.ops("@r%d+,pr", n); return ins;
+        case 0x27: o.set("ldc.l"); o.ops("@r%d+,vbr", n); return ins;
+        case 0x28: o.set("shll16");o.ops("r%d", n); return ins;
+        case 0x29: o.set("shlr16");o.ops("r%d", n); return ins;
+        case 0x2A: o.set("lds");   o.ops("r%d,pr", n); return ins;
+        case 0x2B: o.set("jmp");   o.ops("@r%d", n); ins.IsBranch = true; return ins;
+        case 0x2E: o.set("ldc");   o.ops("r%d,vbr", n); return ins;
+        case 0x0F: o.set("mac.w"); o.ops("@r%d+,@r%d+", m, n); return ins;
+        }
+        break;
+
+    case 0x5:  o.set("mov.l"); o.ops("@(0x%X,r%d),r%d", d4 * 4, m, n); return ins;
+
+    case 0x6:
+        switch (op & 0xF) {
+        case 0x0: o.set("mov.b"); o.ops("@r%d,r%d", m, n); return ins;
+        case 0x1: o.set("mov.w"); o.ops("@r%d,r%d", m, n); return ins;
+        case 0x2: o.set("mov.l"); o.ops("@r%d,r%d", m, n); return ins;
+        case 0x3: o.set("mov");   o.ops("r%d,r%d", m, n); return ins;
+        case 0x4: o.set("mov.b"); o.ops("@r%d+,r%d", m, n); return ins;
+        case 0x5: o.set("mov.w"); o.ops("@r%d+,r%d", m, n); return ins;
+        case 0x6: o.set("mov.l"); o.ops("@r%d+,r%d", m, n); return ins;
+        case 0x7: o.set("not");   o.ops("r%d,r%d", m, n); return ins;
+        case 0x8: o.set("swap.b");o.ops("r%d,r%d", m, n); return ins;
+        case 0x9: o.set("swap.w");o.ops("r%d,r%d", m, n); return ins;
+        case 0xA: o.set("negc");  o.ops("r%d,r%d", m, n); return ins;
+        case 0xB: o.set("neg");   o.ops("r%d,r%d", m, n); return ins;
+        case 0xC: o.set("extu.b");o.ops("r%d,r%d", m, n); return ins;
+        case 0xD: o.set("extu.w");o.ops("r%d,r%d", m, n); return ins;
+        case 0xE: o.set("exts.b");o.ops("r%d,r%d", m, n); return ins;
+        case 0xF: o.set("exts.w");o.ops("r%d,r%d", m, n); return ins;
+        }
+        break;
+
+    case 0x7:  o.set("add"); o.ops("#0x%X,r%d", (uint8_t)imm, n); return ins;
+
+    case 0x8:
+        switch ((op >> 8) & 0xF) {
+        case 0x0: o.set("mov.b"); o.ops("r0,@(0x%X,r%d)", d4, m); return ins;
+        case 0x1: o.set("mov.w"); o.ops("r0,@(0x%X,r%d)", d4 * 2, m); return ins;
+        case 0x4: o.set("mov.b"); o.ops("@(0x%X,r%d),r0", d4, m); return ins;
+        case 0x5: o.set("mov.w"); o.ops("@(0x%X,r%d),r0", d4 * 2, m); return ins;
+        case 0x8: o.set("cmp/eq");o.ops("#0x%X,r0", (uint8_t)imm); return ins;
+        case 0x9: { const uint32_t t = address + 4 + s8ext(op) * 2;
+                    o.set("bt"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                    ins.IsBranch = ins.IsConditional = true; return ins; }
+        case 0xB: { const uint32_t t = address + 4 + s8ext(op) * 2;
+                    o.set("bf"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                    ins.IsBranch = ins.IsConditional = true; return ins; }
+        case 0xD: { const uint32_t t = address + 4 + s8ext(op) * 2;
+                    o.set("bt.s"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                    ins.IsBranch = ins.IsConditional = true; return ins; }
+        case 0xF: { const uint32_t t = address + 4 + s8ext(op) * 2;
+                    o.set("bf.s"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                    ins.IsBranch = ins.IsConditional = true; return ins; }
+        }
+        break;
+
+    case 0x9: { const uint32_t t = address + 4 + (op & 0xFF) * 2;
+                o.set("mov.w"); o.ops("@(0x%08X),r%d", t, n); return ins; }
+
+    case 0xA: { const uint32_t t = address + 4 + s12(op) * 2;
+                o.set("bra"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                ins.IsBranch = true; return ins; }
+
+    case 0xB: { const uint32_t t = address + 4 + s12(op) * 2;
+                o.set("bsr"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
+                ins.IsBranch = ins.IsCall = true; return ins; }
+
+    case 0xC:
+        switch ((op >> 8) & 0xF) {
+        case 0x0: o.set("mov.b"); o.ops("r0,@(0x%X,gbr)", imm); return ins;
+        case 0x1: o.set("mov.w"); o.ops("r0,@(0x%X,gbr)", imm * 2); return ins;
+        case 0x2: o.set("mov.l"); o.ops("r0,@(0x%X,gbr)", imm * 4); return ins;
+        case 0x3: o.set("trapa"); o.ops("#0x%X", imm); ins.IsCall = true; return ins;
+        case 0x4: o.set("mov.b"); o.ops("@(0x%X,gbr),r0", imm); return ins;
+        case 0x5: o.set("mov.w"); o.ops("@(0x%X,gbr),r0", imm * 2); return ins;
+        case 0x6: o.set("mov.l"); o.ops("@(0x%X,gbr),r0", imm * 4); return ins;
+        case 0x7: { const uint32_t t = (address & ~3u) + 4 + imm * 4;
+                    o.set("mova"); o.ops("@(0x%08X),r0", t); return ins; }
+        case 0x8: o.set("tst");   o.ops("#0x%X,r0", imm); return ins;
+        case 0x9: o.set("and");   o.ops("#0x%X,r0", imm); return ins;
+        case 0xA: o.set("xor");   o.ops("#0x%X,r0", imm); return ins;
+        case 0xB: o.set("or");    o.ops("#0x%X,r0", imm); return ins;
+        case 0xC: o.set("tst.b"); o.ops("#0x%X,@(r0,gbr)", imm); return ins;
+        case 0xD: o.set("and.b"); o.ops("#0x%X,@(r0,gbr)", imm); return ins;
+        case 0xE: o.set("xor.b"); o.ops("#0x%X,@(r0,gbr)", imm); return ins;
+        case 0xF: o.set("or.b");  o.ops("#0x%X,@(r0,gbr)", imm); return ins;
+        }
+        break;
+
+    case 0xD: { const uint32_t t = (address & ~3u) + 4 + (op & 0xFF) * 4;
+                o.set("mov.l"); o.ops("@(0x%08X),r%d", t, n); return ins; }
+
+    case 0xE:  o.set("mov"); o.ops("#0x%X,r%d", (uint8_t)imm, n); return ins;
+
+    case 0xF:  break;   // no FPU on plain SH-2: illegal
+    }
+
+    // Fell through: illegal / unimplemented.
+    ins.Mnemonic = ".word";
+    o.ops("0x%04X", op);
+    ins.IsValid = false;
+    return ins;
+}
+
+DisassembledInstruction Sh2DecodeAt(uint32_t address, const uint8_t* bytes, size_t size)
+{
+    if (!bytes || size < 2)
+    {
+        DisassembledInstruction ins;
+        ins.Address = address;
+        ins.Mnemonic = "????";
+        ins.IsValid = false;
+        return ins;
+    }
+    const uint16_t op = (uint16_t)((bytes[0] << 8) | bytes[1]);   // big-endian
+    return Sh2Decode(address, op);
+}
+
+}  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.h
+++ b/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.h
@@ -1,0 +1,37 @@
+// SH-2 disassembler — pure, self-contained (no emulator, no ImGui). Decodes a
+// single 16-bit big-endian SH-2 opcode into structured fields so the Assembly
+// panel can syntax-colour and follow branches. Hitachi SH-2 (SuperH) as used by
+// the Saturn's master/slave CPUs; instructions are 2 bytes, big-endian.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace sfe
+{
+
+struct DisassembledInstruction
+{
+    uint32_t                Address = 0;
+    uint16_t                Opcode = 0;
+    std::string             Mnemonic;                 // e.g. "mov.l", "bt"
+    std::string             Operands;                 // e.g. "r0,@(0x1234,r3)"
+    bool                    HasBranchTarget = false;  // BranchTarget is valid
+    uint32_t                BranchTarget = 0;         // resolved PC-relative target
+    bool                    IsBranch = false;         // any control-flow change
+    bool                    IsCall = false;           // bsr/bsrf/jsr/trapa
+    bool                    IsReturn = false;         // rts/rte
+    bool                    IsConditional = false;    // bt/bf/bt.s/bf.s
+    bool                    IsValid = false;          // false -> illegal/unknown opcode
+};
+
+// Decode one opcode located at 'address'. Never throws; unknown encodings return a
+// ".word 0xXXXX" instruction with IsValid=false.
+DisassembledInstruction Sh2Decode(uint32_t address, uint16_t opcode);
+
+// Convenience: read a big-endian opcode from 'bytes' (>= 2 bytes) at 'address'.
+// Returns an "????" instruction with IsValid=false if fewer than 2 bytes remain.
+DisassembledInstruction Sh2DecodeAt(uint32_t address, const uint8_t* bytes, size_t size);
+
+}  // namespace sfe


### PR DESCRIPTION
Standalone SH-2 (SuperH) disassembler for the Assembly panel. Pure C++14 — no emulator, no ImGui — so it unit-tests end to end now and de-risks the live Assembly view (Phase 3).

Decodes one 16-bit big-endian opcode into **structured** fields (mnemonic, operands, resolved branch target, is-branch/call/return/conditional, validity) rather than one preformatted string, per the spec.

- Full SH-2 instruction set across all 16 opcode groups: moves (reg/indirect/post-inc/pre-dec/displacement/PC-relative/GBR), ALU, shifts + rotates, control-register loads/stores (SR/GBR/VBR/MACH/MACL/PR), system ops, and control flow.
- PC-relative **branch targets** computed for `bt`/`bf`/`bt.s`/`bf.s` (8-bit disp) and `bra`/`bsr` (12-bit disp); PC-relative **data-load** targets for `mov.w`/`mov.l @(disp,PC)` and `mova` (with the `& ~3` PC alignment).
- Unknown / FPU-space encodings return `.word 0xXXXX` with `IsValid=false`.

**Verification**
- Curated known-encoding tests (moves, ALU, shifts, `jsr`/`jmp`/`rts`/`rte`/`trapa`), branch-target math, and an **exhaustive sweep**: all 65536 opcodes decode without crashing — 53512 to real instructions, the rest correctly flagged illegal.
- Compiled into all three frontend targets; C++14-clean. Not yet wired to a panel (that's Phase 3, which needs the emulator to export SH-2 PC/registers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_