### PR TITLE
Debugger: simplify + de-duplicate the Watch/disassembler code

### DIFF
--- a/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.cpp
@@ -2,14 +2,17 @@
 
 #include <cstring>
 
+#include "SaturnRegions.h"   // one home for the Saturn region sizes
+
 namespace sfe
 {
 
 namespace
 {
-// Saturn CPU memory map (the regions the snapshot captures). Addresses are
-// normalized to their canonical mirror first (the SH-2 sees WRAM/VDP at several
-// cache/through mirrors that share the low 27 bits).
+// Saturn CPU memory map (the regions the snapshot captures). Bases are the CPU-
+// visible addresses; sizes come from the shared SaturnRegions.h constants.
+// Addresses are normalized to their canonical mirror first (the SH-2 sees
+// WRAM/VDP at several cache/through mirrors that share the low 27 bits).
 struct Region
 {
     uint32_t     base;
@@ -17,16 +20,16 @@ struct Region
     se_vram_kind kind;
 };
 constexpr Region kRegions[] = {
-    { 0x00200000u, 0x00100000u, SE_VRAM_KIND_WRAM_LOW  },  // Low work RAM (1 MiB)
-    { 0x06000000u, 0x00100000u, SE_VRAM_KIND_WRAM_HIGH },  // High work RAM (1 MiB)
-    { 0x05C00000u, 0x00080000u, SE_VRAM_KIND_VDP1_VRAM },  // VDP1 VRAM (512 KiB)
-    { 0x05E00000u, 0x00080000u, SE_VRAM_KIND_VDP2_VRAM },  // VDP2 VRAM (512 KiB)
-    { 0x05F00000u, 0x00001000u, SE_VRAM_KIND_CRAM      },  // Color RAM (4 KiB)
+    { 0x00200000u, kWramSize,     SE_VRAM_KIND_WRAM_LOW  },  // Low work RAM
+    { 0x06000000u, kWramSize,     SE_VRAM_KIND_WRAM_HIGH },  // High work RAM
+    { 0x05C00000u, kVdp1VramSize, SE_VRAM_KIND_VDP1_VRAM },  // VDP1 VRAM
+    { 0x05E00000u, kVdp2VramSize, SE_VRAM_KIND_VDP2_VRAM },  // VDP2 VRAM
+    { 0x05F00000u, kCramSize,     SE_VRAM_KIND_CRAM      },  // Color RAM
 };
 
 // VDP register windows, served through the register getters (not se_read_vram).
-constexpr uint32_t kVdp1RegBase = 0x05D00000u, kVdp1RegSize = 0x18u;
-constexpr uint32_t kVdp2RegBase = 0x05F80000u, kVdp2RegSize = 0x120u;
+constexpr uint32_t kVdp1RegBase = 0x05D00000u, kVdp1RegSize = kVdp1RegBytes;
+constexpr uint32_t kVdp2RegBase = 0x05F80000u, kVdp2RegSize = kVdp2RegBytes;
 
 uint32_t Canonical(uint32_t addr)
 {

--- a/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.h
+++ b/SaturnExplorer/FrontEnd/src/Debug/MemoryBackend.h
@@ -3,9 +3,11 @@
 // interface; the concrete backend reads from an se_context (which the live driver
 // or a savestate fills), so no Yabause-specific code reaches the UI widgets.
 //
-// Reads are expressed as a batch so a future remote/async backend can coalesce
-// them; the current ContextBackend serves them synchronously from the already
-// captured snapshot (a fast local copy — it never blocks on I/O).
+// Reads are expressed as a batch so a backend can coalesce them; the current
+// ContextBackend serves them synchronously from the already-captured snapshot (a
+// fast local copy — it never blocks on I/O). Note the return is synchronous: a
+// remote/async backend would change this seam to a request-id + poll (a breaking
+// change, not additive), so today's signature is not yet async-ready.
 #pragma once
 
 #include <cstdint>

--- a/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/Sh2Disasm.cpp
@@ -23,9 +23,8 @@ struct Out
     }
 };
 
-int8_t  s8(uint16_t v)  { return (int8_t)(v & 0xFF); }
-int32_t s12(uint16_t v) { int32_t d = v & 0xFFF; if (d & 0x800) d |= ~0xFFF; return d; }
-int32_t s8ext(uint16_t v){ return (int32_t)s8(v); }
+int32_t s8ext(uint16_t v) { return (int32_t)(int8_t)(v & 0xFF); }
+int32_t s12(uint16_t v)   { int32_t d = v & 0xFFF; if (d & 0x800) d |= ~0xFFF; return d; }
 }  // namespace
 
 DisassembledInstruction Sh2Decode(uint32_t address, uint16_t op)
@@ -212,18 +211,16 @@ DisassembledInstruction Sh2Decode(uint32_t address, uint16_t op)
         case 0x4: o.set("mov.b"); o.ops("@(0x%X,r%d),r0", d4, m); return ins;
         case 0x5: o.set("mov.w"); o.ops("@(0x%X,r%d),r0", d4 * 2, m); return ins;
         case 0x8: o.set("cmp/eq");o.ops("#0x%X,r0", (uint8_t)imm); return ins;
-        case 0x9: { const uint32_t t = address + 4 + s8ext(op) * 2;
-                    o.set("bt"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
-                    ins.IsBranch = ins.IsConditional = true; return ins; }
-        case 0xB: { const uint32_t t = address + 4 + s8ext(op) * 2;
-                    o.set("bf"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
-                    ins.IsBranch = ins.IsConditional = true; return ins; }
-        case 0xD: { const uint32_t t = address + 4 + s8ext(op) * 2;
-                    o.set("bt.s"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
-                    ins.IsBranch = ins.IsConditional = true; return ins; }
-        case 0xF: { const uint32_t t = address + 4 + s8ext(op) * 2;
-                    o.set("bf.s"); o.ops("0x%08X", t); ins.HasBranchTarget = true; ins.BranchTarget = t;
-                    ins.IsBranch = ins.IsConditional = true; return ins; }
+        // Conditional PC-relative branches: same 8-bit-disp target, differ only by
+        // mnemonic (bt/bf and their delayed-slot variants).
+        case 0x9: case 0xB: case 0xD: case 0xF: {
+            const int sub = (op >> 8) & 0xF;
+            const char* mn = sub == 0x9 ? "bt" : sub == 0xB ? "bf"
+                           : sub == 0xD ? "bt.s" : "bf.s";
+            const uint32_t t = address + 4 + s8ext(op) * 2;
+            o.set(mn); o.ops("0x%08X", t);
+            ins.HasBranchTarget = true; ins.BranchTarget = t;
+            ins.IsBranch = ins.IsConditional = true; return ins; }
         }
         break;
 

--- a/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
@@ -150,15 +150,17 @@ bool IsPlausibleSaturnAddress(uint32_t addr)
 {
     const uint32_t a = addr & 0x07FFFFFFu;
     struct R { uint32_t lo, hi; };
+    // RAM/VRAM/CRAM extents come from the shared size constants; the register and
+    // BIOS entries are deliberately broad "plausible" windows, not exact sizes.
     static const R kOk[] = {
-        { 0x00000000u, 0x0007FFFFu },  // BIOS
-        { 0x00200000u, 0x002FFFFFu },  // Low work RAM
-        { 0x05C00000u, 0x05C7FFFFu },  // VDP1 VRAM
-        { 0x05D00000u, 0x05D0FFFFu },  // VDP1 regs
-        { 0x05E00000u, 0x05E7FFFFu },  // VDP2 VRAM
-        { 0x05F00000u, 0x05F00FFFu },  // CRAM
-        { 0x05F80000u, 0x05F8FFFFu },  // VDP2 regs
-        { 0x06000000u, 0x060FFFFFu },  // High work RAM
+        { 0x00000000u, 0x0007FFFFu },                        // BIOS
+        { 0x00200000u, 0x00200000u + kWramSize - 1 },        // Low work RAM
+        { 0x05C00000u, 0x05C00000u + kVdp1VramSize - 1 },    // VDP1 VRAM
+        { 0x05D00000u, 0x05D0FFFFu },                        // VDP1 regs
+        { 0x05E00000u, 0x05E00000u + kVdp2VramSize - 1 },    // VDP2 VRAM
+        { 0x05F00000u, 0x05F00000u + kCramSize - 1 },        // CRAM
+        { 0x05F80000u, 0x05F8FFFFu },                        // VDP2 regs
+        { 0x06000000u, 0x06000000u + kWramSize - 1 },        // High work RAM
     };
     for (const R& r : kOk)
     {

--- a/SaturnExplorer/FrontEnd/src/Debug/WatchList.h
+++ b/SaturnExplorer/FrontEnd/src/Debug/WatchList.h
@@ -25,8 +25,8 @@ uint32_t     WatchTypeSize(WatchType t);            // bytes read (1/2/4)
 bool         WatchTypeFromName(const char* s, WatchType& out);
 extern const WatchType kAllWatchTypes[8];
 
-// One watch. Name/expression/type/enabled persist; the rest is transient runtime
-// state (resolved address, last value, change highlight) and is not serialized.
+// One watch — the persisted fields only. The transient runtime state (resolved
+// address, last value, change highlight) lives in the panel's per-row scratch.
 struct WatchEntry
 {
     uint64_t    id = 0;              // stable, for stale-response matching
@@ -34,11 +34,6 @@ struct WatchEntry
     std::string expression = "0x06000000";
     WatchType   type = WatchType::U16;
     bool        enabled = true;
-
-    // Runtime (updated by the refresh loop / panel).
-    bool        resolved = false;
-    uint32_t    address = 0;
-    std::string resolveError;       // set when the expression is invalid
 };
 
 // Address-expression resolver seam: today "0xADDR [+|- N]"; later symbols/pointers.

--- a/SaturnExplorer/FrontEnd/src/WatchPanel.cpp
+++ b/SaturnExplorer/FrontEnd/src/WatchPanel.cpp
@@ -48,24 +48,25 @@ void WatchPanel::Refresh(IMemoryBackend& backend, IExpressionResolver& resolver)
     for (WatchEntry& e : mList.Entries())
     {
         Row& row = RowFor(e);
-        uint32_t addr = 0;
-        std::string err;
-        if (resolver.Resolve(row.exprBuf, addr, err))
+        // Expressions only change on edit/import, so resolve once per new text and
+        // reuse the cached address on subsequent refreshes (no string churn at 10Hz).
+        if (row.resolvedExpr != row.exprBuf)
         {
-            row.resolved = true;
+            row.resolvedExpr = row.exprBuf;
+            uint32_t addr = 0;
+            std::string err;
+            row.resolved = resolver.Resolve(row.exprBuf, addr, err);
             row.address = addr;
-            row.error.clear();
+            row.error = row.resolved ? std::string() : err;
         }
-        else
+        if (!row.resolved)
         {
-            row.resolved = false;
-            row.error = err;
             row.hasValue = false;
             row.value = WatchValue{};
             continue;
         }
         if (!e.enabled) { continue; }
-        reqs.push_back({ addr, WatchTypeSize(e.type) });
+        reqs.push_back({ row.address, WatchTypeSize(e.type) });
         ids.push_back(e.id);
         types.push_back(e.type);
     }
@@ -176,8 +177,7 @@ void WatchPanel::Draw(IMemoryBackend& backend, IExpressionResolver& resolver,
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 0));
         ImGui::SetNextItemWidth(-FLT_MIN);
         if (mFocusNameRow == (int)i) { ImGui::SetKeyboardFocusHere(); mFocusNameRow = -1; }
-        if (ImGui::InputText("##name", row.nameBuf, sizeof(row.nameBuf)))
-        { /* live edit; commit below */ }
+        ImGui::InputText("##name", row.nameBuf, sizeof(row.nameBuf));   // commits below
         if (ImGui::IsItemDeactivatedAfterEdit()) e.name = row.nameBuf;
 
         // Address / Expression (borderless inline edit; normalize + resolve on commit).
@@ -330,6 +330,11 @@ void WatchPanel::DoExport(IPlatform& platform)
     }
 }
 
+// Best-effort session store: a fixed file in the working directory. This is a
+// native-desktop stopgap that deliberately bypasses IPlatform — on the web build
+// it lands in the ephemeral MEMFS and is effectively a no-op. When a proper
+// per-user/app-state seam is added to IPlatform, this should move onto it. Import
+// and Export (the durable, user-driven paths) already go through IPlatform.
 void WatchPanel::LoadSession()
 {
     std::ifstream f(kSessionFile, std::ios::binary);

--- a/SaturnExplorer/FrontEnd/src/WatchPanel.h
+++ b/SaturnExplorer/FrontEnd/src/WatchPanel.h
@@ -38,7 +38,9 @@ private:
         bool        seeded = false;
         char        nameBuf[128] = {};
         char        exprBuf[64] = {};
-        // Resolution + last read.
+        // Resolution + last read. 'resolvedExpr' memoizes the last expression we
+        // resolved so the refresh loop only re-resolves when the text changes.
+        std::string resolvedExpr;
         bool        resolved = false;
         uint32_t    address = 0;
         std::string error;
@@ -60,7 +62,6 @@ private:
     std::unordered_map<uint64_t, Row> mRows;   // by entry id
     float     mRefreshAccum = 0.0f;
     float     mRefreshHz = 10.0f;
-    int       mContextRow = -1;                // row index whose menu is open
     int       mFocusNameRow = -1;              // "Edit" jumped focus here
     std::string mNotice;                        // one-line status (import/export)
     float     mNoticeTime = 0.0f;


### PR DESCRIPTION
Cleanup pass (`/simplify`) over the Phase 1–2 debugger code — **no behavior change**. Four parallel review angles (reuse, simplification, efficiency, altitude) converged on region-table duplication plus a handful of dead-code/efficiency items.

**Reuse / altitude — one region-size source of truth**
- `MemoryBackend`'s region table and `IsPlausibleSaturnAddress` now derive WRAM/VRAM/CRAM/register extents from the shared `SaturnRegions.h` constants instead of re-hardcoding them (this was a third copy); dropped the redundant `kVdp1RegSize`/`kVdp2RegSize`.

**Simplification — dead state removed**
- `WatchEntry`'s never-read runtime fields (`resolved`/`address`/`resolveError` — the panel's `Row` holds the live copies) and the unused `WatchPanel::mContextRow`.
- SH-2 disassembler: folded `s8` into `s8ext`; collapsed the four identical `bt`/`bf`/`bt.s`/`bf.s` cases into one.
- Dropped an empty-bodied `InputText` `if`.

**Efficiency**
- Watch refresh resolves an expression only when its text changes (memoized via `Row::resolvedExpr`) instead of re-resolving every entry at 10 Hz.

**Altitude — scope-honesty comments**
- Marked the fixed-CWD session store as a native-only stopgap that should move onto an `IPlatform` app-state seam; softened the `MemoryBackend` comment that overstated async-readiness.

**Skipped (out of scope for `/simplify`):** reconciling the new `DecodeRgb555` with the core's `se::Rgb555ToRgba` — they use **different channel order**, so unifying them changes colours (a correctness question for `/code-review`, flagged separately). Also skipped: swapping `MemoryReadResult::bytes` for a fixed `uint8_t[4]` (the interface is intentionally arbitrary-size), and the ALU nibble→mnemonic table refactor (current one-line-per-case is already clear).

**Verified:** `sh2_test` (curated + exhaustive 65536-opcode sweep) and `watch_test` (expression/formatting/JSON/address-map) both still pass; desktop links; web config compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_