### PR TITLE
Fix RGB555 channel order (red/blue swap) in Watch + FB viewer

### DIFF
--- a/SaturnExplorer/FrontEnd/src/App.cpp
+++ b/SaturnExplorer/FrontEnd/src/App.cpp
@@ -1349,9 +1349,7 @@ void App::DrawVdp1Framebuffer(IPlatform& platform)
             if (w == 0) return;                           // erased -> transparent
             if (mFbMode == 1)                              // Raw RGB555
             {
-                const uint8_t r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
-                out[0] = (r5 << 3) | (r5 >> 2); out[1] = (g5 << 3) | (g5 >> 2);
-                out[2] = (b5 << 3) | (b5 >> 2); out[3] = 255;
+                DecodeRgb555(w, out[0], out[1], out[2]); out[3] = 255;
                 return;
             }
             if (mFbMode == 2)                              // Priority heatmap
@@ -1364,9 +1362,7 @@ void App::DrawVdp1Framebuffer(IPlatform& platform)
             // Resolved: direct RGB, else colour-bank index through CRAM.
             if (spclmd && (w & 0x8000))
             {
-                const uint8_t r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
-                out[0] = (r5 << 3) | (r5 >> 2); out[1] = (g5 << 3) | (g5 >> 2);
-                out[2] = (b5 << 3) | (b5 >> 2); out[3] = 255;
+                DecodeRgb555(w, out[0], out[1], out[2]); out[3] = 255;
                 return;
             }
             const uint16_t idx = w & kSprColorMask[sprType];

--- a/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
+++ b/SaturnExplorer/FrontEnd/src/Debug/WatchList.cpp
@@ -212,7 +212,8 @@ WatchValue FormatWatchValue(WatchType type, const MemoryReadResult& mem)
     case WatchType::RGB555:
     {
         const uint16_t w = (uint16_t)(raw & 0xFFFF);
-        const int r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
+        uint8_t r5, g5, b5;
+        SplitRgb555(w, r5, g5, b5);
         std::snprintf(buf, sizeof(buf), "R%d G%d B%d", r5, g5, b5);
         v.text = buf; v.hasSwatch = true; DecodeRgb555(w, v.r, v.g, v.b);
         v.numeric = w; v.numericMeaningful = false;   // changed = neutral tint

--- a/SaturnExplorer/FrontEnd/src/SaturnRegions.h
+++ b/SaturnExplorer/FrontEnd/src/SaturnRegions.h
@@ -17,13 +17,25 @@ constexpr uint32_t kVdp1FbSize   = 0x40000;   // VDP1 frame buffer (drawn output
 constexpr uint32_t kVdp1RegBytes = 0x18;      // VDP1 register image (TVMR..MODR)
 constexpr uint32_t kVdp2RegBytes = 0x120;     // VDP2 register file
 
+// Split a Saturn RGB555 word into its 5-bit channels. Saturn stores colour as
+// R in bits 0-4, G in 5-9, B in 10-14 (bit 15 ignored) — matches the core's
+// se::Rgb555ToRgba, validated against real dumps.
+inline void SplitRgb555(uint16_t w, uint8_t& r5, uint8_t& g5, uint8_t& b5)
+{
+    r5 = w & 0x1F;
+    g5 = (w >> 5) & 0x1F;
+    b5 = (w >> 10) & 0x1F;
+}
+
 // Expand a Saturn RGB555 word to 8-bit-per-channel (the one place the 5->8 bit
-// replication lives, shared by the palette/FB/watch views).
+// expansion lives, shared by the palette/FB/watch views). Uses the same *255/31
+// scaling as the core's se::Rgb555ToRgba so every view agrees.
 inline void DecodeRgb555(uint16_t w, uint8_t& r, uint8_t& g, uint8_t& b)
 {
-    const uint8_t r5 = (w >> 10) & 0x1F, g5 = (w >> 5) & 0x1F, b5 = w & 0x1F;
-    r = static_cast<uint8_t>((r5 << 3) | (r5 >> 2));
-    g = static_cast<uint8_t>((g5 << 3) | (g5 >> 2));
-    b = static_cast<uint8_t>((b5 << 3) | (b5 >> 2));
+    uint8_t r5, g5, b5;
+    SplitRgb555(w, r5, g5, b5);
+    r = static_cast<uint8_t>(r5 * 255 / 31);
+    g = static_cast<uint8_t>(g5 * 255 / 31);
+    b = static_cast<uint8_t>(b5 * 255 / 31);
 }
 }  // namespace sfe


### PR DESCRIPTION
Fixes a red/blue swap in the new frontend RGB555 decoders (Watch swatch + text, VDP1 Framebuffer viewer). Saturn stores colour as **R in bits 0-4, B in bits 10-14** (the layout the core's validated `se::Rgb555ToRgba` uses); the frontend `DecodeRgb555` and the Watch RGB555 text put red in the high bits, so a pure-red pixel rendered as blue. Independent of the earlier endianness (byte-swap) fix.

`DecodeRgb555` now splits channels correctly (new `SplitRgb555` helper) and uses the same `*255/31` scaling as the core; the Watch text and the FB viewer's raw + direct-RGB paths route through it. Verified: `0x001F` → `#FF0000` / `R31 G0 B0`; `watch_test` updated with a channel-order guard and passes; desktop links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_