### PR TITLE
Fix live pause: record SH-2 regs; fix apply.py memory poke

### DIFF
--- a/SaturnExplorer/FrontEnd/src/FrameRecorder.cpp
+++ b/SaturnExplorer/FrontEnd/src/FrameRecorder.cpp
@@ -109,6 +109,13 @@ void FrameRecorder::Capture(se_context* ctx, uint64_t frameNumber)
         raw.vdp2Regs[o / 2] = se_get_vdp2_register(ctx, o);
     }
 
+    // SH-2 registers, so the Assembly panel (and status-bar PC) keep working while
+    // paused/scrubbing — reading a recorded frame is otherwise just like live.
+    for (int cpu = 0; cpu < 2; ++cpu)
+    {
+        raw.hasSh2[cpu] = se_get_sh2_regs(ctx, cpu, &raw.sh2[cpu]) == SE_OK;
+    }
+
     {
         std::lock_guard<std::mutex> lk(mQMtx);
         if (mQueue.size() >= kMaxQueued)
@@ -150,9 +157,11 @@ void FrameRecorder::Worker()
         CompressRegion(raw.vdp1Fb,   f.vdp1Fb,   mLzScratch);
         f.vdp1Regs = std::move(raw.vdp1Regs);
         f.vdp2Regs = std::move(raw.vdp2Regs);
+        f.sh2[0] = raw.sh2[0]; f.sh2[1] = raw.sh2[1];
+        f.hasSh2[0] = raw.hasSh2[0]; f.hasSh2[1] = raw.hasSh2[1];
         f.bytes = f.vdp1Vram.lz.size() + f.vdp2Vram.lz.size() + f.cram.lz.size() +
                   f.wramLow.lz.size() + f.wramHigh.lz.size() + f.vdp1Fb.lz.size() +
-                  f.vdp1Regs.size() * 2 + f.vdp2Regs.size() * 2;
+                  f.vdp1Regs.size() * 2 + f.vdp2Regs.size() * 2 + sizeof(f.sh2);
 
         std::lock_guard<std::mutex> lk(mRingMtx);
         mBytes += f.bytes;
@@ -222,13 +231,15 @@ bool FrameRecorder::Select(size_t i, se_data_source* out)
         DecompressRegion(f.vdp1Fb, mSelVdp1Fb);
         mSelVdp1Regs = f.vdp1Regs;
         mSelVdp2Regs = f.vdp2Regs;
+        mSelSh2[0] = f.sh2[0]; mSelSh2[1] = f.sh2[1];
+        mSelHasSh2[0] = f.hasSh2[0]; mSelHasSh2[1] = f.hasSh2[1];
     }
 
     std::memset(out, 0, sizeof(*out));
     out->abi_version = SE_ABI_VERSION;
     out->capabilities = SE_CAP_VDP1_VRAM | SE_CAP_VDP2_VRAM | SE_CAP_CRAM |
                         SE_CAP_MAIN_RAM | SE_CAP_VDP1_REGS | SE_CAP_VDP2_REGS |
-                        SE_CAP_VDP1_FB;
+                        SE_CAP_VDP1_FB | SE_CAP_SH2_REGS;
     out->user = this;
     out->read_vdp1_vram = CbVdp1;
     out->read_vdp2_vram = CbVdp2;
@@ -237,6 +248,7 @@ bool FrameRecorder::Select(size_t i, se_data_source* out)
     out->read_vdp1_fb   = CbVdp1Fb;
     out->read_vdp1_reg  = CbVdp1Reg;
     out->read_vdp2_reg  = CbVdp2Reg;
+    out->read_sh2_regs  = CbSh2Regs;
     // No close callback: the scratch is owned by this recorder, not the context.
     return true;
 }
@@ -281,6 +293,14 @@ uint16_t FrameRecorder::CbVdp2Reg(void* u, uint32_t reg)
     const std::vector<uint16_t>& v = static_cast<FrameRecorder*>(u)->mSelVdp2Regs;
     const size_t i = reg >> 1;
     return i < v.size() ? v[i] : 0;
+}
+int FrameRecorder::CbSh2Regs(void* u, int cpu, se_sh2_regs* out)
+{
+    if (cpu < 0 || cpu > 1 || !out) { return 0; }
+    FrameRecorder* r = static_cast<FrameRecorder*>(u);
+    if (!r->mSelHasSh2[cpu]) { return 0; }   // frame predates SH-2 capture / absent
+    *out = r->mSelSh2[cpu];
+    return 1;
 }
 
 }  // namespace sfe

--- a/SaturnExplorer/FrontEnd/src/FrameRecorder.h
+++ b/SaturnExplorer/FrontEnd/src/FrameRecorder.h
@@ -45,6 +45,8 @@ public:
         Region   vdp1Vram, vdp2Vram, cram, wramLow, wramHigh, vdp1Fb;
         std::vector<uint16_t> vdp1Regs;   // by hw offset >> 1
         std::vector<uint16_t> vdp2Regs;
+        se_sh2_regs sh2[2] = {};          // [0] master, [1] slave (Assembly panel)
+        bool        hasSh2[2] = { false, false };
         size_t   bytes = 0;               // compressed footprint of this frame
     };
 
@@ -75,6 +77,8 @@ private:
         uint64_t frameNumber = 0;
         std::vector<uint8_t>  vdp1Vram, vdp2Vram, cram, wramLow, wramHigh, vdp1Fb;
         std::vector<uint16_t> vdp1Regs, vdp2Regs;
+        se_sh2_regs sh2[2] = {};
+        bool        hasSh2[2] = { false, false };
     };
 
     void Worker();
@@ -101,6 +105,8 @@ private:
     // read by the data-source callbacks below). Outlives the created context.
     std::vector<uint8_t>  mSelVdp1, mSelVdp2, mSelCram, mSelWramLow, mSelWramHigh, mSelVdp1Fb;
     std::vector<uint16_t> mSelVdp1Regs, mSelVdp2Regs;
+    se_sh2_regs           mSelSh2[2] = {};
+    bool                  mSelHasSh2[2] = { false, false };
 
     // Data-source callbacks (static; 'user' is this recorder).
     static size_t CbVdp1(void* u, uint32_t off, void* dst, size_t size);
@@ -110,6 +116,7 @@ private:
     static size_t CbVdp1Fb(void* u, uint32_t off, void* dst, size_t size);
     static uint16_t CbVdp1Reg(void* u, uint32_t reg);
     static uint16_t CbVdp2Reg(void* u, uint32_t reg);
+    static int      CbSh2Regs(void* u, int cpu, se_sh2_regs* out);
 };
 
 }  // namespace sfe

--- a/SaturnExplorer/Integration/Yabause/README.md
+++ b/SaturnExplorer/Integration/Yabause/README.md
@@ -128,15 +128,20 @@ Yabause's byte writer (also inserted by `apply.py`):
 
 ```c
 static void SeExpWriteByte(unsigned int addr, unsigned char val) {
-    MappedMemoryWriteByte((u32)addr, (u8)val);
+    MappedMemoryWriteByteNocache(MSH2, (u32)addr, (u8)val);
 }
 /* ... in YabauseInit(), after SeExportInit(): */
 SeExportSetMemWriteHook(SeExpWriteByte);
 ```
 
 Writing byte-by-byte at Saturn addresses keeps big-endian order without a manual
-swap. Without this hook, Hex Editor edits still apply to Saturn Explorer's own view
-of the frame but aren't pushed to the emulator.
+swap. Note the writer is `MappedMemoryWriteByteNocache(SH2_struct*, addr, val)` —
+in this Yabause `MappedMemoryWriteByte` is only a function-pointer field on
+`SH2_struct`, not a callable 2-arg function (matches how `yabause.c` already does
+memory writes). `Nocache` writes straight to memory (bypassing the SH-2 cache), the
+conventional debugger poke; the master SH-2 (`MSH2`) is a fine target since both
+cores share the bus. Without this hook, Hex Editor edits still apply to Saturn
+Explorer's own view of the frame but aren't pushed to the emulator.
 
 ### 2b. (Optional) Pause / single-step gate
 To enable the Pause and Step Frame buttons, gate each emulated frame on

--- a/SaturnExplorer/Integration/Yabause/apply.py
+++ b/SaturnExplorer/Integration/Yabause/apply.py
@@ -77,7 +77,11 @@ EDITS = [
      "}\n"
      "static void SeExpWriteByte(unsigned int addr, unsigned char val)\n"
      "{\n"
-     "   MappedMemoryWriteByte((u32)addr, (u8)val);\n"
+     "   /* Nocache = write straight to memory (bypass the SH-2 cache), the\n"
+     "    * conventional debugger poke. The real writer takes (SH2_struct*, addr,\n"
+     "    * val); MappedMemoryWriteByte is only a fn-pointer field on SH2_struct in\n"
+     "    * this Yabause. Master SH-2 is fine — both cores share the bus. */\n"
+     "   MappedMemoryWriteByteNocache(MSH2, (u32)addr, (u8)val);\n"
      "}\n",
      "SeExpBpHit"),
 

--- a/SaturnExplorer/Integration/Yabause/se_export.c
+++ b/SaturnExplorer/Integration/Yabause/se_export.c
@@ -111,9 +111,10 @@ void SeExportSetBreakpointHooks(SeAddExecBpFn add, SeClearBpsFn clear)
     sClearBps = clear;
 }
 
-/* ---- Memory-write hook (v6+). apply.py wires this to Yabause's
- * MappedMemoryWriteByte so the Hex Editor can poke work RAM. Writing byte-by-byte
- * at Saturn addresses keeps big-endian semantics without a manual swap. ---- */
+/* ---- Memory-write hook (v6+). apply.py wires this to the emulator's byte writer
+ * (Yabause: MappedMemoryWriteByteNocache(MSH2, addr, val)) so the Hex Editor can
+ * poke work RAM. Writing byte-by-byte at Saturn addresses keeps big-endian
+ * semantics without a manual swap. ---- */
 typedef void (*SeWriteByteFn)(unsigned int address, unsigned char value);
 static SeWriteByteFn sWriteByte;
 

--- a/SaturnExplorer/Integration/Yabause/se_export.h
+++ b/SaturnExplorer/Integration/Yabause/se_export.h
@@ -62,11 +62,13 @@ void SeExportSetBreakpointHooks(void (*add)(int cpu, unsigned int address),
  * debugger can jump to the PC. A resume / single-step from the debugger clears it. */
 void SeExportNotifyStop(int cpu, unsigned int pc);
 
-/* Wire the module's work-RAM poke to Yabause's byte writer (v6+), so the Hex
- * Editor can edit a running game: write(address, value) should call
- * MappedMemoryWriteByte. May be NULL (writes are then dropped). Writing byte-by-
- * byte at Saturn addresses preserves big-endian order without a manual swap. Call
- * once after SeExportInit, e.g. SeExportSetMemWriteHook(SeYabauseWriteByte). */
+/* Wire the module's work-RAM poke to the emulator's byte writer (v6+), so the Hex
+ * Editor can edit a running game: write(address, value) writes one byte. On this
+ * Yabause that's MappedMemoryWriteByteNocache(MSH2, addr, val) — MappedMemoryWriteByte
+ * is only a function-pointer field on SH2_struct, not a callable function. May be
+ * NULL (writes are then dropped). Writing byte-by-byte at Saturn addresses preserves
+ * big-endian order without a manual swap. Call once after SeExportInit, e.g.
+ * SeExportSetMemWriteHook(SeYabauseWriteByte). */
 void SeExportSetMemWriteHook(void (*write)(unsigned int address, unsigned char value));
 
 /* Frame gate for pause / single-step. Call once at the top of each emulated


### PR DESCRIPTION
Two live-mode bug fixes.

### 1. Assembly panel went blank when paused
Pausing a live connection flips Saturn Explorer into scrub mode, which re-renders
every panel from the frame recorder's ring buffer. The recorder predated the SH-2
debugger and never captured CPU registers, so the rebuilt scrub context lacked
`SE_CAP_SH2_REGS` and `se_get_sh2_regs` returned no data — the Assembly panel fell
back to its "No SH-2 state" message. (Watch/Hex still worked because work RAM *is*
recorded.)

`FrameRecorder` now captures both SH-2 register files per frame and serves them from
`Select()` (`SE_CAP_SH2_REGS` + `read_sh2_regs`), so the Assembly panel keeps working
while paused and follows each frame's PC while scrubbing back through history.

### 2. apply.py memory-poke hook didn't compile against real Yabause
The Hex-Editor write hook called `MappedMemoryWriteByte(addr, val)` — a 2-arg free
function that doesn't exist in this Yabause (there the name is only a function-pointer
field on `SH2_struct`). The real writer is
`MappedMemoryWriteByteNocache(SH2_struct*, addr, val)`, matching how `yabause.c`
already does memory writes. Fixed the canonical `apply.py` + README + `se_export`
docs so a re-copy can't reintroduce the broken 2-arg call. `Nocache` is the
conventional debugger poke (straight to memory, bypassing the SH-2 cache); `MSH2` is
fine as the target since both cores share the bus. (Thanks to the fork report.)

### Verification
- Desktop build clean; web (no `SE_ENABLE_LIVE`) still compiles.
- A recorder round-trip test captures a savestate frame and confirms the rebuilt
  scrub context serves the exact SH-2 registers (master PC `0600521E`) and advertises
  `SE_CAP_SH2_REGS`.
- `apply.py` emits the corrected `MappedMemoryWriteByteNocache(MSH2, …)` poke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x

---
_Generated by [Claude Code](https://claude.ai/code/session_014LAGYEyiW6USGije8geL9x)_